### PR TITLE
Add analyzer rule for `bettys-bike-shop`

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -10,7 +10,7 @@
             "elm/json": "1.1.3",
             "elm-community/list-extra": "8.5.1",
             "jfmengels/elm-review": "2.7.1",
-            "jfmengels/elm-review-simplify": "2.0.11",
+            "jfmengels/elm-review-simplify": "2.0.12",
             "jfmengels/elm-review-unused": "1.1.21",
             "stil4m/elm-syntax": "7.2.8"
         },

--- a/review/elm.json
+++ b/review/elm.json
@@ -8,7 +8,7 @@
         "direct": {
             "elm/core": "1.0.5",
             "jfmengels/elm-review": "2.7.1",
-            "jfmengels/elm-review-simplify": "2.0.11",
+            "jfmengels/elm-review-simplify": "2.0.12",
             "jfmengels/elm-review-unused": "1.1.21",
             "stil4m/elm-syntax": "7.2.9"
         },

--- a/src/Exercise/BettysBikeShop.elm
+++ b/src/Exercise/BettysBikeShop.elm
@@ -1,0 +1,63 @@
+module Exercise.BettysBikeShop exposing (hasFunctionSignatures, ruleConfig)
+
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Elm.Syntax.Declaration as Declaration exposing (Declaration)
+import Elm.Syntax.Node as Node exposing (Node)
+import Review.Rule as Rule exposing (Error, Rule)
+import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
+
+
+ruleConfig : RuleConfig
+ruleConfig =
+    { slug = Just "bettys-bike-shop"
+    , restrictToFiles = Just [ "src/BettysBikeShop.elm" ]
+    , rules = [ CustomRule hasFunctionSignatures ]
+    }
+
+
+hasFunctionSignatures : Rule
+hasFunctionSignatures =
+    Rule.newModuleRuleSchema "elm.bettys-bike-shop.use_signature" []
+        |> Rule.withDeclarationEnterVisitor hasSignatureVisitor
+        |> Rule.withFinalModuleEvaluation finalEvaluation
+        |> Rule.fromModuleRuleSchema
+
+
+
+{- Finding missing type signatures
+
+   We add the error to a context (which is a list of errors) instead of emitting it so we can limit the number of errors to one at the end.
+-}
+
+
+hasSignatureVisitor : Node Declaration -> List (Error {}) -> ( List empty, List (Error {}) )
+hasSignatureVisitor node errors =
+    case Node.value node of
+        Declaration.FunctionDeclaration { declaration, signature } ->
+            case signature of
+                Nothing ->
+                    ( []
+                    , Comment.createError
+                        (Comment "has no signature" "elm.bettys-bike-shop.use_signature" Essential Dict.empty)
+                        (declaration |> Node.value |> .name |> Node.range)
+                        :: errors
+                    )
+
+                Just _ ->
+                    ( [], errors )
+
+        _ ->
+            ( [], errors )
+
+
+
+{- Emitting one error
+
+   We only emit one error at the end to have a simple message "Please add type signatures to all top-level functions"
+-}
+
+
+finalEvaluation : List (Error {}) -> List (Error {})
+finalEvaluation =
+    List.take 1

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -2,6 +2,7 @@ module ReviewConfig exposing (config, ruleConfigs)
 
 import Common.NoUnused
 import Common.Simplify
+import Exercise.BettysBikeShop
 import Exercise.Strain
 import Review.Rule as Rule exposing (Rule)
 import RuleConfig exposing (RuleConfig)
@@ -14,6 +15,8 @@ ruleConfigs =
     , Common.Simplify.ruleConfig
 
     -- Concept Exercises
+    , Exercise.BettysBikeShop.ruleConfig
+
     -- Practice Exercises
     , Exercise.Strain.ruleConfig
     ]

--- a/tests/Exercise/BettysBikeShopTest.elm
+++ b/tests/Exercise/BettysBikeShopTest.elm
@@ -1,0 +1,185 @@
+module Exercise.BettysBikeShopTest exposing (..)
+
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Exercise.BettysBikeShop as BettysBikeShop
+import Review.Rule exposing (Rule)
+import Review.Test
+import Test exposing (Test, describe, test)
+import TestHelper
+
+
+rules : List Rule
+rules =
+    [ BettysBikeShop.hasFunctionSignatures ]
+
+
+exemplar : Test
+exemplar =
+    test "should not report anything for the exemplar" <|
+        \() ->
+            TestHelper.expectNoErrorsForRules rules
+                """
+module BettysBikeShop exposing (penceToPounds, poundsToString)
+
+import String
+
+penceToPounds : Int -> Float
+penceToPounds pence =
+    toFloat pence / 100.0
+
+poundsToString : Float -> String
+poundsToString pounds =
+    "£" ++ String.fromFloat pounds
+"""
+
+
+otherSolutions : Test
+otherSolutions =
+    describe "other solutions that are also valid" <|
+        [ test "without the import String" <|
+            \() ->
+                TestHelper.expectNoErrorsForRules rules
+                    """
+module BettysBikeShop exposing (penceToPounds, poundsToString)
+
+penceToPounds : Int -> Float
+penceToPounds pence =
+    toFloat pence / 100.0
+
+poundsToString : Float -> String
+poundsToString pounds =
+    "£" ++ String.fromFloat pounds
+"""
+        , test "importing String.fromFloat" <|
+            \() ->
+                TestHelper.expectNoErrorsForRules rules
+                    """
+module BettysBikeShop exposing (penceToPounds, poundsToString)
+
+import String exposing (fromFloat)
+
+penceToPounds : Int -> Float
+penceToPounds pence =
+    toFloat pence / 100.0
+
+poundsToString : Float -> String
+poundsToString pounds =
+    "£" ++ fromFloat pounds
+"""
+        , test "with a helper function" <|
+            \() ->
+                TestHelper.expectNoErrorsForRules rules
+                    """
+module BettysBikeShop exposing (penceToPounds, poundsToString)
+
+import String
+
+penceToPounds : Int -> Float
+penceToPounds pence =
+    toFloat pence / 100.0
+
+poundsToString : Float -> String
+poundsToString =
+    String.fromFloat >> addPoundsSymbol
+
+addPoundsSymbol : String -> String
+addPoundsSymbol =
+    (++) "£"
+"""
+        ]
+
+
+noFuctionSignature : Test
+noFuctionSignature =
+    let
+        comment =
+            Comment "has no signature" "elm.bettys-bike-shop.use_signature" Essential Dict.empty
+    in
+    describe "solutions without function signatures" <|
+        [ test "no function signature on penceToPounds" <|
+            \() ->
+                """
+module BettysBikeShop exposing (penceToPounds, poundsToString)
+
+import String
+
+-- penceToPounds : Int -> Float
+penceToPounds pence =
+    toFloat pence / 100.0
+
+poundsToString : Float -> String
+poundsToString pounds =
+    "£" ++ String.fromFloat pounds
+"""
+                    |> Review.Test.run BettysBikeShop.hasFunctionSignatures
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "penceToPounds"
+                            |> Review.Test.atExactly { start = { row = 7, column = 1 }, end = { row = 7, column = 14 } }
+                        ]
+        , test "no function signature on poundsToString" <|
+            \() ->
+                """
+module BettysBikeShop exposing (penceToPounds, poundsToString)
+
+import String
+
+penceToPounds : Int -> Float
+penceToPounds pence =
+    toFloat pence / 100.0
+
+-- poundsToString : Float -> String
+poundsToString pounds =
+    "£" ++ String.fromFloat pounds
+"""
+                    |> Review.Test.run BettysBikeShop.hasFunctionSignatures
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "poundsToString"
+                            |> Review.Test.atExactly { start = { row = 11, column = 1 }, end = { row = 11, column = 15 } }
+                        ]
+        , test "no function signature at all only emits one message" <|
+            \() ->
+                """
+module BettysBikeShop exposing (penceToPounds, poundsToString)
+
+import String
+
+-- penceToPounds : Int -> Float
+penceToPounds pence =
+    toFloat pence / 100.0
+
+-- poundsToString : Float -> String
+poundsToString pounds =
+    "£" ++ String.fromFloat pounds
+"""
+                    |> Review.Test.run BettysBikeShop.hasFunctionSignatures
+                    |> Review.Test.expectErrors
+                        -- location of the error is on last function found, but it won't be shown to students anyway
+                        [ TestHelper.createExpectedErrorUnder comment "poundsToString"
+                            |> Review.Test.atExactly { start = { row = 11, column = 1 }, end = { row = 11, column = 15 } }
+                        ]
+        , test "helper function with no signature" <|
+            \() ->
+                """
+module BettysBikeShop exposing (penceToPounds, poundsToString)
+
+import String
+
+penceToPounds : Int -> Float
+penceToPounds pence =
+    toFloat pence / 100.0
+
+poundsToString : Float -> String
+poundsToString =
+    String.fromFloat >> addPoundsSymbol
+
+-- addPoundsSymbol : String -> String
+addPoundsSymbol =
+    (++) "£"
+"""
+                    |> Review.Test.run BettysBikeShop.hasFunctionSignatures
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "addPoundsSymbol"
+                            |> Review.Test.atExactly { start = { row = 15, column = 1 }, end = { row = 15, column = 16 } }
+                        ]
+        ]

--- a/tests/Exercise/BettysBikeShopTest.elm
+++ b/tests/Exercise/BettysBikeShopTest.elm
@@ -11,7 +11,7 @@ import TestHelper
 
 rules : List Rule
 rules =
-    [ BettysBikeShop.hasFunctionSignatures ]
+    [ BettysBikeShop.hasFunctionSignatures, BettysBikeShop.importString ]
 
 
 exemplar : Test
@@ -37,21 +37,7 @@ poundsToString pounds =
 otherSolutions : Test
 otherSolutions =
     describe "other solutions that are also valid" <|
-        [ test "without the import String" <|
-            \() ->
-                TestHelper.expectNoErrorsForRules rules
-                    """
-module BettysBikeShop exposing (penceToPounds, poundsToString)
-
-penceToPounds : Int -> Float
-penceToPounds pence =
-    toFloat pence / 100.0
-
-poundsToString : Float -> String
-poundsToString pounds =
-    "£" ++ String.fromFloat pounds
-"""
-        , test "importing String.fromFloat" <|
+        [ test "importing String.fromFloat" <|
             \() ->
                 TestHelper.expectNoErrorsForRules rules
                     """
@@ -66,6 +52,22 @@ penceToPounds pence =
 poundsToString : Float -> String
 poundsToString pounds =
     "£" ++ fromFloat pounds
+"""
+        , test "importing String with an alias" <|
+            \() ->
+                TestHelper.expectNoErrorsForRules rules
+                    """
+module BettysBikeShop exposing (penceToPounds, poundsToString)
+
+import String as S
+
+penceToPounds : Int -> Float
+penceToPounds pence =
+    toFloat pence / 100.0
+
+poundsToString : Float -> String
+poundsToString pounds =
+    "£" ++ S.fromFloat pounds
 """
         , test "with a helper function" <|
             \() ->
@@ -181,5 +183,29 @@ addPoundsSymbol =
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder comment "addPoundsSymbol"
                             |> Review.Test.atExactly { start = { row = 15, column = 1 }, end = { row = 15, column = 16 } }
+                        ]
+        ]
+
+
+noImportString : Test
+noImportString =
+    describe "solutions that do no import String" <|
+        [ test "without the import String" <|
+            \() ->
+                """
+module BettysBikeShop exposing (penceToPounds, poundsToString)
+
+penceToPounds : Int -> Float
+penceToPounds pence =
+    toFloat pence / 100.0
+
+poundsToString : Float -> String
+poundsToString pounds =
+    "£" ++ String.fromFloat pounds
+"""
+                    |> Review.Test.run BettysBikeShop.importString
+                    |> Review.Test.expectGlobalErrors
+                        [ TestHelper.createExpectedGlobalError
+                            (Comment "does not import String" "elm.bettys-bike-shop.import_string" Essential Dict.empty)
                         ]
         ]


### PR DESCRIPTION
Closes #17.
[Sister PR here](https://github.com/exercism/website-copy/pull/2186).

The `design.md` document mentions two things:
-   Verify that functions have type annotations.
-  Verify that the whitespace adheres to community defaults.

This PR covers the first one, but I don't know how to address the second one (which is also mentioned for a couple of other concept exercises). 
Formatting in Elm is so reliant on `elm-format` that I don't think it makes sense to ask students to emulate that. [There is an open issue](https://github.com/exercism/exercism/issues/5986) that talks about adding a format button on the web editor. I'm not sure how far that had gone, but if we could have an `elm-format` button, that would solve everything.