### PR TITLE
Remove curl specific version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /opt/analyzer
 ENV PATH="/opt/analyzer/bin:${PATH}"
 
 # Install curl to download executables
-RUN apk add --update --no-cache curl=7.80.0-r0 \
+RUN apk add --update --no-cache curl \
   && mkdir -p bin
 
 # Install jq


### PR DESCRIPTION
The analyzer is down at the moment because `lts-alpine` is not happy with the specific version of curl.
This should fix it.
EDIT: it's not actually down, sorry. The new check didn't get released, that's all.