### PR TITLE
Top scorers

### DIFF
--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -88,5 +88,11 @@ formatPlayerMustUseMap =
         }
 
 
-
--- Maybe.map and Maybe.withDefault should be used in formatPlayer
+formatPlayerMustUseWithDefault : Rule
+formatPlayerMustUseWithDefault =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "formatPlayer"
+        , findFunctions = [ FromExternalModule [ "Maybe" ] "withDefault" ]
+        , find = Some
+        , comment = Comment "Doesn't use Maybe.withDefault" "elm.top-scorers.use_withDefault" Essential Dict.empty
+        }

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -16,10 +16,8 @@ ruleConfig =
         , CustomRule resetPlayerGoalCountMustUseInsert
         , CustomRule formatPlayersCannotUseSort
         , CustomRule combineGamesMustUseMerge
-        , CustomRule aggregateScorersMustUseFoldl
-        , CustomRule aggregateScorersMustUseUpdateGoalCountForPlayer
-        , CustomRule formatPlayerMustUseMap
-        , CustomRule formatPlayerMustUseWithDefault
+        , CustomRule aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer
+        , CustomRule formatPlayerMustUseMapAndWithDefault
         ]
     }
 
@@ -64,41 +62,21 @@ combineGamesMustUseMerge =
         }
 
 
-aggregateScorersMustUseFoldl : Rule
-aggregateScorersMustUseFoldl =
+aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer : Rule
+aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer =
     Analyzer.functionCalls
         { calledFrom = TopFunction "aggregateScorers"
-        , findFunctions = [ FromExternalModule [ "List" ] "foldl" ]
-        , find = Some
-        , comment = Comment "Doesn't use List.foldl" "elm.top-scorers.use_foldl" Essential Dict.empty
+        , findFunctions = [ FromExternalModule [ "List" ] "foldl", FromSameModule "updateGoalCountForPlayer" ]
+        , find = All
+        , comment = Comment "Doesn't use List.foldl and updateGoalCountForPlayer" "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty
         }
 
 
-aggregateScorersMustUseUpdateGoalCountForPlayer : Rule
-aggregateScorersMustUseUpdateGoalCountForPlayer =
-    Analyzer.functionCalls
-        { calledFrom = TopFunction "aggregateScorers"
-        , findFunctions = [ FromSameModule "updateGoalCountForPlayer" ]
-        , find = Some
-        , comment = Comment "Doesn't use updateGoalCountForPlayer" "elm.top-scorers.use_updateGoalCountForPlayer" Essential Dict.empty
-        }
-
-
-formatPlayerMustUseMap : Rule
-formatPlayerMustUseMap =
+formatPlayerMustUseMapAndWithDefault : Rule
+formatPlayerMustUseMapAndWithDefault =
     Analyzer.functionCalls
         { calledFrom = TopFunction "formatPlayer"
-        , findFunctions = [ FromExternalModule [ "Maybe" ] "map" ]
+        , findFunctions = [ FromExternalModule [ "Maybe" ] "map", FromExternalModule [ "Maybe" ] "withDefault" ]
         , find = Some
-        , comment = Comment "Doesn't use Maybe.map" "elm.top-scorers.use_map" Essential Dict.empty
-        }
-
-
-formatPlayerMustUseWithDefault : Rule
-formatPlayerMustUseWithDefault =
-    Analyzer.functionCalls
-        { calledFrom = TopFunction "formatPlayer"
-        , findFunctions = [ FromExternalModule [ "Maybe" ] "withDefault" ]
-        , find = Some
-        , comment = Comment "Doesn't use Maybe.withDefault" "elm.top-scorers.use_withDefault" Essential Dict.empty
+        , comment = Comment "Doesn't use Maybe.map and Maybe.withDefault" "elm.top-scorers.use_map_and_withDefault" Essential Dict.empty
         }

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -46,3 +46,13 @@ formatPlayersCannotUseSort =
         , find = None
         , comment = Comment "Uses List.sort" "elm.top-scorers.dont_use_sort" Essential Dict.empty
         }
+
+
+combineGamesMustUseMerge : Rule
+combineGamesMustUseMerge =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "combineGames"
+        , findFunctions = [ FromExternalModule [ "Dict" ] "merge" ]
+        , find = Some
+        , comment = Comment "Doesn't use Dict.merge" "elm.top-scorers.use_merge" Essential Dict.empty
+        }

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -68,5 +68,15 @@ aggregateScorersMustUseFoldl =
         }
 
 
+aggregateScorersMustUseUpdateGoalCountForPlayer : Rule
+aggregateScorersMustUseUpdateGoalCountForPlayer =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "aggregateScorers"
+        , findFunctions = [ FromSameModule "updateGoalCountForPlayer" ]
+        , find = Some
+        , comment = Comment "Doesn't use updateGoalCountForPlayer" "elm.top-scorers.use_updateGoalCountForPlayer" Essential Dict.empty
+        }
+
+
 
 -- updateGoalCountForPlayer and List.foldl must be used in aggregateScorers

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -1,0 +1,27 @@
+module Exercise.TopScorers exposing (..)
+
+import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Review.Rule exposing (Rule)
+import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
+
+
+ruleConfig : RuleConfig
+ruleConfig =
+    { slug = Just "top-scorers"
+    , restrictToFiles = Just [ "src/TopScorers.elm" ]
+    , rules =
+        [ CustomRule removeInsignificantPlayersMustUseFilter
+        ]
+    }
+
+
+removeInsignificantPlayersMustUseFilter : Rule
+removeInsignificantPlayersMustUseFilter =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "removeInsignificantPlayers"
+        , findFunctions = [ FromExternalModule [ "Dict" ] "filter" ]
+        , find = Some
+        , comment = Comment "Uses the Dict module" "elm.top-scorers.use_filter" Essential Dict.empty
+        }

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -14,6 +14,12 @@ ruleConfig =
     , rules =
         [ CustomRule removeInsignificantPlayersMustUseFilter
         , CustomRule resetPlayerGoalCountMustUseInsert
+        , CustomRule formatPlayersCannotUseSort
+        , CustomRule combineGamesMustUseMerge
+        , CustomRule aggregateScorersMustUseFoldl
+        , CustomRule aggregateScorersMustUseUpdateGoalCountForPlayer
+        , CustomRule formatPlayerMustUseMap
+        , CustomRule formatPlayerMustUseWithDefault
         ]
     }
 

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -78,5 +78,15 @@ aggregateScorersMustUseUpdateGoalCountForPlayer =
         }
 
 
+formatPlayerMustUseMap : Rule
+formatPlayerMustUseMap =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "formatPlayer"
+        , findFunctions = [ FromExternalModule [ "Maybe" ] "map" ]
+        , find = Some
+        , comment = Comment "Doesn't use Maybe.map" "elm.top-scorers.use_map" Essential Dict.empty
+        }
 
--- updateGoalCountForPlayer and List.foldl must be used in aggregateScorers
+
+
+-- Maybe.map and Maybe.withDefault should be used in formatPlayer

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -17,7 +17,7 @@ ruleConfig =
         , CustomRule formatPlayersCannotUseSort
         , CustomRule combineGamesMustUseMerge
         , CustomRule aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer
-        , CustomRule formatPlayerMustUseMapAndWithDefault
+        , CustomRule formatPlayerMustUseWithDefault
         ]
     }
 
@@ -72,11 +72,11 @@ aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer =
         }
 
 
-formatPlayerMustUseMapAndWithDefault : Rule
-formatPlayerMustUseMapAndWithDefault =
+formatPlayerMustUseWithDefault : Rule
+formatPlayerMustUseWithDefault =
     Analyzer.functionCalls
         { calledFrom = TopFunction "formatPlayer"
-        , findFunctions = [ FromExternalModule [ "Maybe" ] "map", FromExternalModule [ "Maybe" ] "withDefault" ]
+        , findFunctions = [ FromExternalModule [ "Maybe" ] "withDefault" ]
         , find = Some
-        , comment = Comment "Doesn't use Maybe.map and Maybe.withDefault" "elm.top-scorers.use_map_and_withDefault" Essential Dict.empty
+        , comment = Comment "Doesn't use Maybe.withDefault" "elm.top-scorers.use_withDefault" Essential Dict.empty
         }

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -56,3 +56,17 @@ combineGamesMustUseMerge =
         , find = Some
         , comment = Comment "Doesn't use Dict.merge" "elm.top-scorers.use_merge" Essential Dict.empty
         }
+
+
+aggregateScorersMustUseFoldl : Rule
+aggregateScorersMustUseFoldl =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "aggregateScorers"
+        , findFunctions = [ FromExternalModule [ "List" ] "foldl" ]
+        , find = Some
+        , comment = Comment "Doesn't use List.foldl" "elm.top-scorers.use_foldl" Essential Dict.empty
+        }
+
+
+
+-- updateGoalCountForPlayer and List.foldl must be used in aggregateScorers

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -13,6 +13,7 @@ ruleConfig =
     , restrictToFiles = Just [ "src/TopScorers.elm" ]
     , rules =
         [ CustomRule removeInsignificantPlayersMustUseFilter
+        , CustomRule resetPlayerGoalCountMustUseInsert
         ]
     }
 
@@ -24,4 +25,14 @@ removeInsignificantPlayersMustUseFilter =
         , findFunctions = [ FromExternalModule [ "Dict" ] "filter" ]
         , find = Some
         , comment = Comment "Uses the Dict module" "elm.top-scorers.use_filter" Essential Dict.empty
+        }
+
+
+resetPlayerGoalCountMustUseInsert : Rule
+resetPlayerGoalCountMustUseInsert =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "resetPlayerGoalCount"
+        , findFunctions = [ FromExternalModule [ "Dict" ] "insert" ]
+        , find = Some
+        , comment = Comment "Uses the Dict module" "elm.top-scorers.use_insert" Essential Dict.empty
         }

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -24,7 +24,7 @@ removeInsignificantPlayersMustUseFilter =
         { calledFrom = TopFunction "removeInsignificantPlayers"
         , findFunctions = [ FromExternalModule [ "Dict" ] "filter" ]
         , find = Some
-        , comment = Comment "Uses the Dict module" "elm.top-scorers.use_filter" Essential Dict.empty
+        , comment = Comment "Doesn't use Dict.filter" "elm.top-scorers.use_filter" Essential Dict.empty
         }
 
 
@@ -34,5 +34,15 @@ resetPlayerGoalCountMustUseInsert =
         { calledFrom = TopFunction "resetPlayerGoalCount"
         , findFunctions = [ FromExternalModule [ "Dict" ] "insert" ]
         , find = Some
-        , comment = Comment "Uses the Dict module" "elm.top-scorers.use_insert" Essential Dict.empty
+        , comment = Comment "Doesn't use Dict.insert" "elm.top-scorers.use_insert" Essential Dict.empty
+        }
+
+
+formatPlayersCannotUseSort : Rule
+formatPlayersCannotUseSort =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "formatPlayers"
+        , findFunctions = [ FromExternalModule [ "List" ] "sort" ]
+        , find = None
+        , comment = Comment "Uses List.sort" "elm.top-scorers.dont_use_sort" Essential Dict.empty
         }

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -4,6 +4,7 @@ import Common.NoUnused
 import Common.Simplify
 import Exercise.BettysBikeShop
 import Exercise.Strain
+import Exercise.TopScorers
 import Review.Rule as Rule exposing (Rule)
 import RuleConfig exposing (RuleConfig)
 
@@ -16,6 +17,7 @@ ruleConfigs =
 
     -- Concept Exercises
     , Exercise.BettysBikeShop.ruleConfig
+    , Exercise.TopScorers.ruleConfig
 
     -- Practice Exercises
     , Exercise.Strain.ruleConfig

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -91,7 +91,20 @@ module TopScorers exposing (..)
 
 aggregateScorers : List PlayerName -> Dict PlayerName Int
 aggregateScorers playerNames =
-    Debug.todo "implement this function"
+    playerNames
+    |> List.foldr
+        (\\name acc ->
+            Dict.update name
+                (\\existingCount ->
+                    case existingCount of
+                        Just count ->
+                            Just (count + 1)
+                        Nothing ->
+                            Just 1
+                )
+                acc
+        )
+        Dict.empty
             """
                     |> Review.Test.run TopScorers.aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer
                     |> Review.Test.expectErrors

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -20,8 +20,8 @@ rules =
     ]
 
 
-failures : Test
-failures =
+tests : Test
+tests =
     describe "Analyser"
         [ test "should report that Dict.filter must be used" <|
             \() ->

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -16,6 +16,7 @@ rules =
     [ TopScorers.removeInsignificantPlayersMustUseFilter
     , TopScorers.resetPlayerGoalCountMustUseInsert
     , TopScorers.formatPlayersCannotUseSort
+    , TopScorers.combineGamesMustUseMerge
     ]
 
 
@@ -63,6 +64,20 @@ formatPlayers players =
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder (Comment "Uses List.sort" "elm.top-scorers.dont_use_sort" Essential Dict.empty) "List.sort"
                             |> Review.Test.atExactly { start = { row = 6, column = 26 }, end = { row = 6, column = 35 } }
+                        ]
+        , test "should report that Dict.merge must be used" <|
+            \() ->
+                """
+module TopScorers exposing (..)
+
+combineGames : Dict PlayerName Int -> Dict PlayerName Int -> Dict PlayerName Int
+combineGames game1 game2 =
+    Debug.todo "implement this function"
+            """
+                    |> Review.Test.run TopScorers.combineGamesMustUseMerge
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Dict.merge" "elm.top-scorers.use_merge" Essential Dict.empty) "combineGames"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
                         ]
         , test "should not report anything for the exemplar" <|
             \() ->

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -75,7 +75,9 @@ module TopScorers exposing (..)
 
 combineGames : Dict PlayerName Int -> Dict PlayerName Int -> Dict PlayerName Int
 combineGames game1 game2 =
-    Debug.todo "implement this function"
+    game1
+    |> Dict.toList
+    |> List.foldr (\\(name,score) g -> Dict.update name (update score) g) game2
             """
                     |> Review.Test.run TopScorers.combineGamesMustUseMerge
                     |> Review.Test.expectErrors

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -20,6 +20,7 @@ rules =
     , TopScorers.aggregateScorersMustUseFoldl
     , TopScorers.aggregateScorersMustUseUpdateGoalCountForPlayer
     , TopScorers.formatPlayerMustUseMap
+    , TopScorers.formatPlayerMustUseWithDefault
     ]
 
 
@@ -122,6 +123,20 @@ formatPlayer playerName playerGoalCounts =
                     |> Review.Test.run TopScorers.formatPlayerMustUseMap
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Maybe.map" "elm.top-scorers.use_map" Essential Dict.empty) "formatPlayer"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
+                        ]
+        , test "should report that Maybe.withDefault must be used" <|
+            \() ->
+                """
+module TopScorers exposing (..)
+
+formatPlayer : PlayerName -> Dict PlayerName Int -> String
+formatPlayer playerName playerGoalCounts =
+    Debug.todo "implement this function"
+            """
+                    |> Review.Test.run TopScorers.formatPlayerMustUseWithDefault
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Maybe.withDefault" "elm.top-scorers.use_withDefault" Essential Dict.empty) "formatPlayer"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
                         ]
         , test "should not report anything for the exemplar" <|

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -1,7 +1,5 @@
 module Exercise.TopScorersTest exposing (..)
 
--- import Expect exposing (Expectation)
-
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Exercise.TopScorers as TopScorers

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -118,7 +118,9 @@ module TopScorers exposing (..)
 
 formatPlayer : PlayerName -> Dict PlayerName Int -> String
 formatPlayer playerName playerGoalCounts =
-    Debug.todo "implement this function"
+    case Dict.get playerName playerGoalCounts of
+        Just n  -> playerName ++ ": " ++ String.fromInt n
+        Nothing -> playerName ++ ": 0"
             """
                     |> Review.Test.run TopScorers.formatPlayerMustUseMapAndWithDefault
                     |> Review.Test.expectErrors

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -1,0 +1,103 @@
+module Exercise.TopScorersTest exposing (..)
+
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Exercise.TopScorers as TopScorers
+import Expect exposing (Expectation)
+import Review.Rule exposing (Rule)
+import Review.Test
+import Test exposing (Test, describe, test)
+import TestHelper
+
+
+rules : List Rule
+rules =
+    [ TopScorers.removeInsignificantPlayersMustUseFilter ]
+
+
+removeInsignificantPlayersMustUseFilter : Test
+removeInsignificantPlayersMustUseFilter =
+    test "should report that Dict.filter must be used" <|
+        \() ->
+            """
+module TopScorers exposing (..)
+
+removeInsignificantPlayers : Int -> Dict PlayerName Int -> Dict PlayerName Int
+removeInsignificantPlayers goalThreshold playerGoalCounts =
+    Debug.todo "implement this function"
+            """
+                |> Review.Test.run TopScorers.removeInsignificantPlayersMustUseFilter
+                |> Review.Test.expectErrors
+                    [ TestHelper.createExpectedErrorUnder (Comment "Uses the Dict module" "elm.top-scorers.use_filter" Essential Dict.empty) "removeInsignificantPlayers"
+                        |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 27 } }
+                    ]
+
+
+exemplar : Test
+exemplar =
+    test "should not report anything for the exemplar" <|
+        \() ->
+            TestHelper.expectNoErrorsForRules rules
+                """
+module TopScorers exposing (..)
+
+import Dict exposing (Dict)
+import TopScorersSupport exposing (PlayerName)
+
+
+updateGoalCountForPlayer : PlayerName -> Dict PlayerName Int -> Dict PlayerName Int
+updateGoalCountForPlayer playerName playerGoalCounts =
+    let
+        updatePlayer existingGoalCount =
+            case existingGoalCount of
+                Just goalCount ->
+                    Just (goalCount + 1)
+
+                Nothing ->
+                    Just 1
+    in
+    Dict.update playerName updatePlayer playerGoalCounts
+
+
+aggregateScorers : List PlayerName -> Dict PlayerName Int
+aggregateScorers playerNames =
+    List.foldl updateGoalCountForPlayer Dict.empty playerNames
+
+
+removeInsignificantPlayers : Int -> Dict PlayerName Int -> Dict PlayerName Int
+removeInsignificantPlayers goalThreshold playerGoalCounts =
+    Dict.filter (\\_ goalCount -> goalCount >= goalThreshold) playerGoalCounts
+
+
+resetPlayerGoalCount : PlayerName -> Dict PlayerName Int -> Dict PlayerName Int
+resetPlayerGoalCount playerName playerGoalCounts =
+    Dict.insert playerName 0 playerGoalCounts
+
+
+formatPlayer : PlayerName -> Dict PlayerName Int -> String
+formatPlayer playerName playerGoalCounts =
+    Dict.get playerName playerGoalCounts
+        |> Maybe.map (\\goalCount -> playerName ++ ": " ++ String.fromInt goalCount)
+        |> Maybe.withDefault (playerName ++ ": 0")
+
+
+formatPlayers : Dict PlayerName Int -> String
+formatPlayers players =
+    Dict.toList players
+        |> List.map (\\( playerName, goalCount ) -> playerName ++ ": " ++ String.fromInt goalCount)
+        |> String.join ", "
+
+
+combineGames : Dict PlayerName Int -> Dict PlayerName Int -> Dict PlayerName Int
+combineGames game1 game2 =
+    Dict.merge
+        -- when only in game 1
+        (\\playerName game1GoalCount playerGoalCounts -> Dict.insert playerName game1GoalCount playerGoalCounts)
+        -- when in game 1 and game2
+        (\\playerName game1GoalCount game2GoalCount playerGoalCounts -> Dict.insert playerName (game1GoalCount + game2GoalCount) playerGoalCounts)
+        -- when only in game 2
+        (\\playerName game2GoalCount playerGoalCounts -> Dict.insert playerName game2GoalCount playerGoalCounts)
+        game1
+        game2
+        Dict.empty
+"""

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -30,7 +30,9 @@ module TopScorers exposing (..)
 
 removeInsignificantPlayers : Int -> Dict PlayerName Int -> Dict PlayerName Int
 removeInsignificantPlayers goalThreshold playerGoalCounts =
-    Debug.todo "implement this function"
+    Dict.toList playerGoalCounts
+    |> List.filter (\\t -> Tuple.second t >= goalThreshold)
+    |> Dict.fromList
             """
                     |> Review.Test.run TopScorers.removeInsignificantPlayersMustUseFilter
                     |> Review.Test.expectErrors

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -18,6 +18,7 @@ rules =
     , TopScorers.formatPlayersCannotUseSort
     , TopScorers.combineGamesMustUseMerge
     , TopScorers.aggregateScorersMustUseFoldl
+    , TopScorers.aggregateScorersMustUseUpdateGoalCountForPlayer
     ]
 
 
@@ -92,6 +93,20 @@ aggregateScorers playerNames =
                     |> Review.Test.run TopScorers.aggregateScorersMustUseFoldl
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use List.foldl" "elm.top-scorers.use_foldl" Essential Dict.empty) "aggregateScorers"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 17 } }
+                        ]
+        , test "should report that updateGoalCountForPlayer must be used" <|
+            \() ->
+                """
+module TopScorers exposing (..)
+
+aggregateScorers : List PlayerName -> Dict PlayerName Int
+aggregateScorers playerNames =
+    Debug.todo "implement this function"
+            """
+                    |> Review.Test.run TopScorers.aggregateScorersMustUseUpdateGoalCountForPlayer
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use updateGoalCountForPlayer" "elm.top-scorers.use_updateGoalCountForPlayer" Essential Dict.empty) "aggregateScorers"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 17 } }
                         ]
         , test "should not report anything for the exemplar" <|

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -19,6 +19,7 @@ rules =
     , TopScorers.combineGamesMustUseMerge
     , TopScorers.aggregateScorersMustUseFoldl
     , TopScorers.aggregateScorersMustUseUpdateGoalCountForPlayer
+    , TopScorers.formatPlayerMustUseMap
     ]
 
 
@@ -108,6 +109,20 @@ aggregateScorers playerNames =
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use updateGoalCountForPlayer" "elm.top-scorers.use_updateGoalCountForPlayer" Essential Dict.empty) "aggregateScorers"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 17 } }
+                        ]
+        , test "should report that Maybe.map must be used" <|
+            \() ->
+                """
+module TopScorers exposing (..)
+
+formatPlayer : PlayerName -> Dict PlayerName Int -> String
+formatPlayer playerName playerGoalCounts =
+    Debug.todo "implement this function"
+            """
+                    |> Review.Test.run TopScorers.formatPlayerMustUseMap
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Maybe.map" "elm.top-scorers.use_map" Essential Dict.empty) "formatPlayer"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
                         ]
         , test "should not report anything for the exemplar" <|
             \() ->

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -1,12 +1,13 @@
 module Exercise.TopScorersTest exposing (..)
 
+-- import Expect exposing (Expectation)
+
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Exercise.TopScorers as TopScorers
-import Expect exposing (Expectation)
 import Review.Rule exposing (Rule)
 import Review.Test
-import Test exposing (Test, describe, test)
+import Test exposing (Test, test)
 import TestHelper
 
 

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -17,6 +17,7 @@ rules =
     , TopScorers.resetPlayerGoalCountMustUseInsert
     , TopScorers.formatPlayersCannotUseSort
     , TopScorers.combineGamesMustUseMerge
+    , TopScorers.aggregateScorersMustUseFoldl
     ]
 
 
@@ -78,6 +79,20 @@ combineGames game1 game2 =
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Dict.merge" "elm.top-scorers.use_merge" Essential Dict.empty) "combineGames"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
+                        ]
+        , test "should report that List.foldl must be used" <|
+            \() ->
+                """
+module TopScorers exposing (..)
+
+aggregateScorers : List PlayerName -> Dict PlayerName Int
+aggregateScorers playerNames =
+    Debug.todo "implement this function"
+            """
+                    |> Review.Test.run TopScorers.aggregateScorersMustUseFoldl
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use List.foldl" "elm.top-scorers.use_foldl" Essential Dict.empty) "aggregateScorers"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 17 } }
                         ]
         , test "should not report anything for the exemplar" <|
             \() ->

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -34,6 +34,24 @@ removeInsignificantPlayers goalThreshold playerGoalCounts =
                     ]
 
 
+resetPlayerGoalCountMustUseInsert : Test
+resetPlayerGoalCountMustUseInsert =
+    test "should report that Dict.insert must be used" <|
+        \() ->
+            """
+module TopScorers exposing (..)
+
+resetPlayerGoalCount : PlayerName -> Dict PlayerName Int -> Dict PlayerName Int
+resetPlayerGoalCount playerName playerGoalCounts =
+    Debug.todo "implement this function"
+            """
+                |> Review.Test.run TopScorers.resetPlayerGoalCountMustUseInsert
+                |> Review.Test.expectErrors
+                    [ TestHelper.createExpectedErrorUnder (Comment "Uses the Dict module" "elm.top-scorers.use_insert" Essential Dict.empty) "resetPlayerGoalCount"
+                        |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 21 } }
+                    ]
+
+
 exemplar : Test
 exemplar =
     test "should not report anything for the exemplar" <|

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -46,7 +46,8 @@ module TopScorers exposing (..)
 
 resetPlayerGoalCount : PlayerName -> Dict PlayerName Int -> Dict PlayerName Int
 resetPlayerGoalCount playerName playerGoalCounts =
-    Debug.todo "implement this function"
+    playerGoalCounts
+    |> Dict.update playerName (\\ _ -> Just 0 )
             """
                     |> Review.Test.run TopScorers.resetPlayerGoalCountMustUseInsert
                     |> Review.Test.expectErrors

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -15,10 +15,8 @@ rules =
     , TopScorers.resetPlayerGoalCountMustUseInsert
     , TopScorers.formatPlayersCannotUseSort
     , TopScorers.combineGamesMustUseMerge
-    , TopScorers.aggregateScorersMustUseFoldl
-    , TopScorers.aggregateScorersMustUseUpdateGoalCountForPlayer
-    , TopScorers.formatPlayerMustUseMap
-    , TopScorers.formatPlayerMustUseWithDefault
+    , TopScorers.aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer
+    , TopScorers.formatPlayerMustUseMapAndWithDefault
     ]
 
 
@@ -81,7 +79,7 @@ combineGames game1 game2 =
                         [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Dict.merge" "elm.top-scorers.use_merge" Essential Dict.empty) "combineGames"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
                         ]
-        , test "should report that List.foldl must be used" <|
+        , test "should report that List.foldl and updateGoalCountForPlayer must be used" <|
             \() ->
                 """
 module TopScorers exposing (..)
@@ -90,26 +88,12 @@ aggregateScorers : List PlayerName -> Dict PlayerName Int
 aggregateScorers playerNames =
     Debug.todo "implement this function"
             """
-                    |> Review.Test.run TopScorers.aggregateScorersMustUseFoldl
+                    |> Review.Test.run TopScorers.aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer
                     |> Review.Test.expectErrors
-                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use List.foldl" "elm.top-scorers.use_foldl" Essential Dict.empty) "aggregateScorers"
+                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use List.foldl and updateGoalCountForPlayer" "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty) "aggregateScorers"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 17 } }
                         ]
-        , test "should report that updateGoalCountForPlayer must be used" <|
-            \() ->
-                """
-module TopScorers exposing (..)
-
-aggregateScorers : List PlayerName -> Dict PlayerName Int
-aggregateScorers playerNames =
-    Debug.todo "implement this function"
-            """
-                    |> Review.Test.run TopScorers.aggregateScorersMustUseUpdateGoalCountForPlayer
-                    |> Review.Test.expectErrors
-                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use updateGoalCountForPlayer" "elm.top-scorers.use_updateGoalCountForPlayer" Essential Dict.empty) "aggregateScorers"
-                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 17 } }
-                        ]
-        , test "should report that Maybe.map must be used" <|
+        , test "should report that Maybe.map and Maybe.withDefault must be used" <|
             \() ->
                 """
 module TopScorers exposing (..)
@@ -118,23 +102,9 @@ formatPlayer : PlayerName -> Dict PlayerName Int -> String
 formatPlayer playerName playerGoalCounts =
     Debug.todo "implement this function"
             """
-                    |> Review.Test.run TopScorers.formatPlayerMustUseMap
+                    |> Review.Test.run TopScorers.formatPlayerMustUseMapAndWithDefault
                     |> Review.Test.expectErrors
-                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Maybe.map" "elm.top-scorers.use_map" Essential Dict.empty) "formatPlayer"
-                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
-                        ]
-        , test "should report that Maybe.withDefault must be used" <|
-            \() ->
-                """
-module TopScorers exposing (..)
-
-formatPlayer : PlayerName -> Dict PlayerName Int -> String
-formatPlayer playerName playerGoalCounts =
-    Debug.todo "implement this function"
-            """
-                    |> Review.Test.run TopScorers.formatPlayerMustUseWithDefault
-                    |> Review.Test.expectErrors
-                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Maybe.withDefault" "elm.top-scorers.use_withDefault" Essential Dict.empty) "formatPlayer"
+                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Maybe.map and Maybe.withDefault" "elm.top-scorers.use_map_and_withDefault" Essential Dict.empty) "formatPlayer"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
                         ]
         , test "should not report anything for the exemplar" <|

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -16,7 +16,7 @@ rules =
     , TopScorers.formatPlayersCannotUseSort
     , TopScorers.combineGamesMustUseMerge
     , TopScorers.aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer
-    , TopScorers.formatPlayerMustUseMapAndWithDefault
+    , TopScorers.formatPlayerMustUseWithDefault
     ]
 
 
@@ -111,7 +111,7 @@ aggregateScorers playerNames =
                         [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use List.foldl and updateGoalCountForPlayer" "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty) "aggregateScorers"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 17 } }
                         ]
-        , test "should report that Maybe.map and Maybe.withDefault must be used" <|
+        , test "should report that Maybe.withDefault must be used" <|
             \() ->
                 """
 module TopScorers exposing (..)
@@ -122,9 +122,9 @@ formatPlayer playerName playerGoalCounts =
         Just n  -> playerName ++ ": " ++ String.fromInt n
         Nothing -> playerName ++ ": 0"
             """
-                    |> Review.Test.run TopScorers.formatPlayerMustUseMapAndWithDefault
+                    |> Review.Test.run TopScorers.formatPlayerMustUseWithDefault
                     |> Review.Test.expectErrors
-                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Maybe.map and Maybe.withDefault" "elm.top-scorers.use_map_and_withDefault" Essential Dict.empty) "formatPlayer"
+                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Maybe.withDefault" "elm.top-scorers.use_withDefault" Essential Dict.empty) "formatPlayer"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
                         ]
         , test "should not report anything for the exemplar" <|


### PR DESCRIPTION
Add analyser rules for the Top Scorers concept exercise

[Sister PR in webste-copy](https://github.com/exercism/website-copy/pull/2224)

Covers the following points from [design.md](https://github.com/exercism/elm/blob/main/exercises/concept/top-scorers/.meta/design.md)

- filter must be used in removeInsignificantPlayers
- insert must be used in resetPlayerCounts
- sort must not be used in formatPlayers
- updateGoalCountForPlayer and List.foldl must be used in aggregateScorers
- Maybe.map and Maybe.withDefault should be used in formatPlayer
- merge must be used in combineGames

@jiegillet 
@mpizenberg