### PR TITLE
Add CI check: all comment paths exist in `website-copy`

### DIFF
--- a/.github/workflows/elm_tests.yml
+++ b/.github/workflows/elm_tests.yml
@@ -71,6 +71,15 @@ jobs:
       - name: Run elm-review on source code
         run: npx elm-review
 
+      - name: Checkout the website-copy-repo
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791
+        with:
+          repository: exercism/website-copy
+          path: website-copy
+
+      - name: Check comment paths exist
+        run: ./bin/check_website-copy_paths.sh website-copy
+
   smoke-test:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/elm_tests.yml
+++ b/.github/workflows/elm_tests.yml
@@ -78,7 +78,9 @@ jobs:
           path: website-copy
 
       - name: Check comment paths exist
-        run: ./bin/check_website-copy_paths.sh website-copy
+        run: |
+          ./bin/build.sh
+          ./bin/check_website-copy_paths.sh website-copy
 
   smoke-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/elm_tests.yml
+++ b/.github/workflows/elm_tests.yml
@@ -71,6 +71,42 @@ jobs:
       - name: Run elm-review on source code
         run: npx elm-review
 
+  check-website-copy-paths:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791
+
+      - name: Cache node_modules
+        id: cache-node_modules
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: node_modules
+          key: node_modules-${{ hashFiles('package.json', 'package-lock.json') }}
+          restore-keys: |
+            node_modules-${{ hashFiles('package.json') }}
+            node_modules-
+
+      - name: Cache ~/.elm
+        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        with:
+          path: ~/.elm
+          key: elm-${{ hashFiles('elm-tooling.json', 'elm.json', 'review/elm.json') }}
+          restore-keys: |
+            elm-${{ hashFiles('elm-tooling.json', 'elm.json') }}
+            elm-${{ hashFiles('elm-tooling.json') }}
+            elm-
+
+      - name: npm ci
+        if: steps.cache-node_modules.outputs.cache-hit != 'true'
+        env:
+          NO_ELM_TOOLING_INSTALL: 1
+        run: npm ci
+
+      - name: elm-tooling install
+        run: npx elm-tooling install
+
       - name: Checkout the website-copy-repo
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791
         with:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ When a new exercise is proposed, corresponding messages must be added on that re
 
 A `Comment` has four fields: 
 - `name`: a description of what went wrong, for internal use only.
-- `comment`: a path pointing to the message location on `exercism/website-copy`.
+- `path`: a path pointing to the message location on `exercism/website-copy`.
 - `commentType`: the gravity of a comment, ranging from essential to celebratory.
 - `params`: a `Dict` of parameters that can be injected into the message on `exercism/website-copy`.
 

--- a/bin/check_website-copy_paths.sh
+++ b/bin/check_website-copy_paths.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e # Make script exit when a command fail.
+set -u # Exit on usage of undeclared variable.
+# set -x # Trace what gets executed.
+set -o pipefail # Catch failures in pipes.
+
+# Command line arguments
+WEBSITE_COPY_DIR=$1
+
+# Extract comment paths
+COMMENT_PATHS=$(echo -n "--extract-comment-paths" | node ./bin/cli.js)
+
+# Check paths
+for path in $COMMENT_PATHS
+do
+  if [ ! -f "$WEBSITE_COPY_DIR/$path" ]; then
+    echo "File $path does not exist"
+    exit 1
+  fi
+done
+
+echo "All paths exist"

--- a/src/Analyzer.elm
+++ b/src/Analyzer.elm
@@ -124,7 +124,7 @@ functionCalls :
     -> Comment
     -> Rule
 functionCalls { calledFrom, findFunctions, find } comment =
-    Rule.newModuleRuleSchemaUsingContextCreator comment.comment (initialContext findFunctions)
+    Rule.newModuleRuleSchemaUsingContextCreator comment.path (initialContext findFunctions)
         |> Rule.withDeclarationEnterVisitor (annotateFunctionDeclaration calledFrom)
         |> Rule.withExpressionEnterVisitor expressionCallsFunction
         |> Rule.withDeclarationExitVisitor annotateLeaveDeclaration

--- a/src/Analyzer.elm
+++ b/src/Analyzer.elm
@@ -120,10 +120,10 @@ functionCalls :
     { calledFrom : CalledFrom
     , findFunctions : List CalledFunction
     , find : Find
-    , comment : Comment
     }
+    -> Comment
     -> Rule
-functionCalls { calledFrom, findFunctions, find, comment } =
+functionCalls { calledFrom, findFunctions, find } comment =
     Rule.newModuleRuleSchemaUsingContextCreator comment.comment (initialContext findFunctions)
         |> Rule.withDeclarationEnterVisitor (annotateFunctionDeclaration calledFrom)
         |> Rule.withExpressionEnterVisitor expressionCallsFunction

--- a/src/Comment.elm
+++ b/src/Comment.elm
@@ -9,6 +9,7 @@ module Comment exposing
     , encodeComment
     , feedbackComment
     , makeSummary
+    , toWebsiteCopyPath
     )
 
 import Dict exposing (Dict)
@@ -31,7 +32,7 @@ type alias Summary =
 
 type alias Comment =
     { name : String
-    , comment : String
+    , path : String
     , commentType : CommentType
     , params : Dict String String
     }
@@ -100,7 +101,7 @@ aggregateComments comments =
 
 
 commentTypeShowOrder : Comment -> ( Int, String )
-commentTypeShowOrder { commentType, comment } =
+commentTypeShowOrder { commentType, path } =
     let
         firstOrder =
             case commentType of
@@ -116,7 +117,7 @@ commentTypeShowOrder { commentType, comment } =
                 Informative ->
                     3
     in
-    ( firstOrder, comment )
+    ( firstOrder, path )
 
 
 commentTypeSummaryOrder : CommentType -> Int
@@ -174,19 +175,19 @@ encodeSummary { summary, comments } =
 
 
 encodeSummaryComment : Comment -> Value
-encodeSummaryComment { comment, commentType, params } =
+encodeSummaryComment { path, commentType, params } =
     Encode.object
-        [ ( "comment", Encode.string comment )
+        [ ( "comment", Encode.string path )
         , ( "type", commentType |> encodeCommentType )
         , ( "params", Encode.dict identity Encode.string params )
         ]
 
 
 encodeComment : Comment -> Value
-encodeComment { name, comment, commentType, params } =
+encodeComment { name, path, commentType, params } =
     Encode.object
         [ ( "name", Encode.string name )
-        , ( "comment", Encode.string comment )
+        , ( "comment", Encode.string path )
         , ( "type", commentType |> encodeCommentType )
         , ( "params", Encode.dict identity Encode.string params )
         ]
@@ -266,3 +267,8 @@ decodeCommentType =
                     Decode.fail ("Invalid comment type " ++ other)
     in
     Decode.string |> Decode.andThen decodeType
+
+
+toWebsiteCopyPath : Comment -> String
+toWebsiteCopyPath { path } =
+    "analyzer-comments/" ++ String.replace "." "/" path ++ ".md"

--- a/src/Common/Simplify.elm
+++ b/src/Common/Simplify.elm
@@ -19,12 +19,16 @@ ruleConfig : RuleConfig
 ruleConfig =
     { slug = Nothing
     , restrictToFiles = Nothing
-    , rules = [ ImportedRule (Simplify.rule Simplify.defaults) simplifyDecoder ]
+    , rules =
+        [ ImportedRule (Simplify.rule Simplify.defaults)
+            simplifyDecoder
+            (Comment "Simplify" "elm.common.simplify" Actionable Dict.empty)
+        ]
     }
 
 
-simplifyDecoder : Decoder Comment
-simplifyDecoder =
+simplifyDecoder : Comment -> Decoder Comment
+simplifyDecoder comment =
     let
         decodeFormatted : Decoder (List String)
         decodeFormatted =
@@ -37,16 +41,15 @@ simplifyDecoder =
         toComment : ( String, List String ) -> Decoder Comment
         toComment ( errorRule, formatted ) =
             if errorRule == "Simplify" then
-                Comment "Simplify"
-                    "elm.common.simplify"
-                    Actionable
-                    (Dict.singleton "message"
-                        (formatted
-                            |> String.concat
-                            |> String.replace "(fix) " ""
-                        )
-                    )
-                    |> Decode.succeed
+                Decode.succeed
+                    { comment
+                        | params =
+                            Dict.singleton "message"
+                                (formatted
+                                    |> String.concat
+                                    |> String.replace "(fix) " ""
+                                )
+                    }
 
             else
                 Decode.fail "not Simplify"

--- a/src/Exercise/BlorkemonCards.elm
+++ b/src/Exercise/BlorkemonCards.elm
@@ -13,48 +13,48 @@ ruleConfig =
     , restrictToFiles = Just [ "src/BlorkemonCards.elm" ]
     , rules =
         [ CustomRule maxPowerUsesMax
+            (Comment "maxPower doesn't use max" "elm.blorkemon-cards.use_max" Essential Dict.empty)
         , CustomRule sortByMonsterNameUsesSortBy
+            (Comment "sortByMonsterName doesn't use List.sortBy" "elm.blorkemon-cards.use_sort_by" Essential Dict.empty)
         , CustomRule expectedWinnerUsesCompareShinyPower
+            (Comment "expectedWinner doesn't use compareShinyPower" "elm.blorkemon-cards.use_shiny_power" Essential Dict.empty)
         , CustomRule expectedWinnerUsesCase
+            (Comment "Doesn't use a case expression" "elm.blorkemon-cards.use_case" Essential Dict.empty)
         ]
     }
 
 
-maxPowerUsesMax : Rule
+maxPowerUsesMax : Comment -> Rule
 maxPowerUsesMax =
     Analyzer.functionCalls
         { calledFrom = TopFunction "maxPower"
         , findFunctions = [ FromExternalModule [ "Basics" ] "max" ]
         , find = Some
-        , comment = Comment "maxPower doesn't use max" "elm.blorkemon-cards.use_max" Essential Dict.empty
         }
 
 
-sortByMonsterNameUsesSortBy : Rule
+sortByMonsterNameUsesSortBy : Comment -> Rule
 sortByMonsterNameUsesSortBy =
     Analyzer.functionCalls
         { calledFrom = TopFunction "sortByMonsterName"
         , findFunctions = [ FromExternalModule [ "List" ] "sortBy" ]
         , find = Some
-        , comment = Comment "sortByMonsterName doesn't use List.sortBy" "elm.blorkemon-cards.use_sort_by" Essential Dict.empty
         }
 
 
-expectedWinnerUsesCompareShinyPower : Rule
+expectedWinnerUsesCompareShinyPower : Comment -> Rule
 expectedWinnerUsesCompareShinyPower =
     Analyzer.functionCalls
         { calledFrom = TopFunction "expectedWinner"
         , findFunctions = [ FromSameModule "compareShinyPower" ]
         , find = Some
-        , comment = Comment "expectedWinner doesn't use compareShinyPower" "elm.blorkemon-cards.use_shiny_power" Essential Dict.empty
         }
 
 
-expectedWinnerUsesCase : Rule
+expectedWinnerUsesCase : Comment -> Rule
 expectedWinnerUsesCase =
     Analyzer.functionCalls
         { calledFrom = TopFunction "expectedWinner"
         , findFunctions = [ CaseBlock ]
         , find = Some
-        , comment = Comment "Doesn't use a case expression" "elm.blorkemon-cards.use_case" Essential Dict.empty
         }

--- a/src/Exercise/MariosMarvellousLasagna.elm
+++ b/src/Exercise/MariosMarvellousLasagna.elm
@@ -11,17 +11,19 @@ ruleConfig : RuleConfig
 ruleConfig =
     { slug = Just "marios-marvellous-lasagna"
     , restrictToFiles = Just [ "src/MariosMarvellousLasagna.elm" ]
-    , rules = [ CustomRule usesLet ]
+    , rules =
+        [ CustomRule usesLet
+            (Comment "Doesn't use a let expression" "elm.marios-marvellous-lasagna.use_let" Essential Dict.empty)
+        ]
     }
 
 
 {-| There should be a `let` used in `remainingTimeInMinutes`
 -}
-usesLet : Rule
+usesLet : Comment -> Rule
 usesLet =
     Analyzer.functionCalls
         { calledFrom = TopFunction "remainingTimeInMinutes"
         , findFunctions = [ LetBlock ]
         , find = Some
-        , comment = Comment "Doesn't use a let expression" "elm.marios-marvellous-lasagna.use_let" Essential Dict.empty
         }

--- a/src/Exercise/Strain.elm
+++ b/src/Exercise/Strain.elm
@@ -11,15 +11,17 @@ ruleConfig : RuleConfig
 ruleConfig =
     { slug = Just "strain"
     , restrictToFiles = Just [ "src/Strain.elm" ]
-    , rules = [ CustomRule doNotUseFilter ]
+    , rules =
+        [ CustomRule doNotUseFilter
+            (Comment "Uses the List module" "elm.strain.do_not_use_filter" Essential Dict.empty)
+        ]
     }
 
 
-doNotUseFilter : Rule
+doNotUseFilter : Comment -> Rule
 doNotUseFilter =
     Analyzer.functionCalls
         { calledFrom = Anywhere
         , findFunctions = [ FromExternalModule [ "List" ] "filter", FromExternalModule [ "List" ] "filterMap" ]
         , find = None
-        , comment = Comment "Uses the List module" "elm.strain.do_not_use_filter" Essential Dict.empty
         }

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -13,70 +13,70 @@ ruleConfig =
     , restrictToFiles = Just [ "src/TopScorers.elm" ]
     , rules =
         [ CustomRule removeInsignificantPlayersMustUseFilter
+            (Comment "Doesn't use Dict.filter" "elm.top-scorers.use_filter" Essential Dict.empty)
         , CustomRule resetPlayerGoalCountMustUseInsert
+            (Comment "Doesn't use Dict.insert" "elm.top-scorers.use_insert" Essential Dict.empty)
         , CustomRule formatPlayersCannotUseSort
+            (Comment "Uses List.sort" "elm.top-scorers.dont_use_sort" Essential Dict.empty)
         , CustomRule combineGamesMustUseMerge
+            (Comment "Doesn't use Dict.merge" "elm.top-scorers.use_merge" Essential Dict.empty)
         , CustomRule aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer
+            (Comment "Doesn't use List.foldl and updateGoalCountForPlayer" "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty)
         , CustomRule formatPlayerMustUseWithDefault
+            (Comment "Doesn't use Maybe.withDefault" "elm.top-scorers.use_withDefault" Essential Dict.empty)
         ]
     }
 
 
-removeInsignificantPlayersMustUseFilter : Rule
+removeInsignificantPlayersMustUseFilter : Comment -> Rule
 removeInsignificantPlayersMustUseFilter =
     Analyzer.functionCalls
         { calledFrom = TopFunction "removeInsignificantPlayers"
         , findFunctions = [ FromExternalModule [ "Dict" ] "filter" ]
         , find = Some
-        , comment = Comment "Doesn't use Dict.filter" "elm.top-scorers.use_filter" Essential Dict.empty
         }
 
 
-resetPlayerGoalCountMustUseInsert : Rule
+resetPlayerGoalCountMustUseInsert : Comment -> Rule
 resetPlayerGoalCountMustUseInsert =
     Analyzer.functionCalls
         { calledFrom = TopFunction "resetPlayerGoalCount"
         , findFunctions = [ FromExternalModule [ "Dict" ] "insert" ]
         , find = Some
-        , comment = Comment "Doesn't use Dict.insert" "elm.top-scorers.use_insert" Essential Dict.empty
         }
 
 
-formatPlayersCannotUseSort : Rule
+formatPlayersCannotUseSort : Comment -> Rule
 formatPlayersCannotUseSort =
     Analyzer.functionCalls
         { calledFrom = TopFunction "formatPlayers"
         , findFunctions = [ FromExternalModule [ "List" ] "sort" ]
         , find = None
-        , comment = Comment "Uses List.sort" "elm.top-scorers.dont_use_sort" Essential Dict.empty
         }
 
 
-combineGamesMustUseMerge : Rule
+combineGamesMustUseMerge : Comment -> Rule
 combineGamesMustUseMerge =
     Analyzer.functionCalls
         { calledFrom = TopFunction "combineGames"
         , findFunctions = [ FromExternalModule [ "Dict" ] "merge" ]
         , find = Some
-        , comment = Comment "Doesn't use Dict.merge" "elm.top-scorers.use_merge" Essential Dict.empty
         }
 
 
-aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer : Rule
+aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer : Comment -> Rule
 aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer =
     Analyzer.functionCalls
         { calledFrom = TopFunction "aggregateScorers"
         , findFunctions = [ FromExternalModule [ "List" ] "foldl", FromSameModule "updateGoalCountForPlayer" ]
         , find = All
-        , comment = Comment "Doesn't use List.foldl and updateGoalCountForPlayer" "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty
         }
 
 
-formatPlayerMustUseWithDefault : Rule
+formatPlayerMustUseWithDefault : Comment -> Rule
 formatPlayerMustUseWithDefault =
     Analyzer.functionCalls
         { calledFrom = TopFunction "formatPlayer"
         , findFunctions = [ FromExternalModule [ "Maybe" ] "withDefault" ]
         , find = Some
-        , comment = Comment "Doesn't use Maybe.withDefault" "elm.top-scorers.use_withDefault" Essential Dict.empty
         }

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -27,7 +27,7 @@ main =
 update : String -> () -> ( (), Cmd msg )
 update input () =
     case input of
-        "--extract-comments" ->
+        "--extract-comment-paths" ->
             ( ()
             , RuleConfig.getComments ReviewConfig.ruleConfigs
                 |> (::) Comment.feedbackComment

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -26,21 +26,32 @@ main =
 
 update : String -> () -> ( (), Cmd msg )
 update input () =
-    let
-        elmReviewErrorDecoders =
-            List.concatMap RuleConfig.getDecoders ReviewConfig.ruleConfigs
-    in
-    case Comment.makeSummary elmReviewErrorDecoders input of
-        Ok output ->
-            ( (), stdout output )
-
-        Err err ->
+    case input of
+        "--extract-comments" ->
             ( ()
-            , [ "Input could not be parsed. \nError:"
-              , Decode.errorToString err
-              , "Input:"
-              , input
-              ]
+            , RuleConfig.getComments ReviewConfig.ruleConfigs
+                |> (::) Comment.feedbackComment
+                |> List.map Comment.toWebsiteCopyPath
                 |> String.join "\n"
-                |> stderr
+                |> stdout
             )
+
+        _ ->
+            let
+                elmReviewErrorDecoders =
+                    RuleConfig.getDecoders ReviewConfig.ruleConfigs
+            in
+            case Comment.makeSummary elmReviewErrorDecoders input of
+                Ok output ->
+                    ( (), stdout output )
+
+                Err err ->
+                    ( ()
+                    , [ "Input could not be parsed. \nError:"
+                      , Decode.errorToString err
+                      , "Input:"
+                      , input
+                      ]
+                        |> String.join "\n"
+                        |> stderr
+                    )

--- a/src/RuleConfig.elm
+++ b/src/RuleConfig.elm
@@ -1,4 +1,4 @@
-module RuleConfig exposing (AnalyzerRule(..), RuleConfig, analyzerRuleToRule, getDecoders, makeConfig)
+module RuleConfig exposing (AnalyzerRule(..), RuleConfig, analyzerRuleToRule, getComments, getDecoders, makeConfig)
 
 import Comment exposing (Comment)
 import Json.Decode exposing (Decoder)
@@ -37,6 +37,16 @@ analyzerRuleToDecoder analyzerRule =
             Just (toDecoder comment)
 
 
+analyzerRuleToComment : AnalyzerRule -> Comment
+analyzerRuleToComment analyzerRule =
+    case analyzerRule of
+        CustomRule _ comment ->
+            comment
+
+        ImportedRule _ _ comment ->
+            comment
+
+
 getRules : RuleConfig -> List Rule
 getRules { rules, restrictToFiles } =
     case restrictToFiles of
@@ -47,9 +57,14 @@ getRules { rules, restrictToFiles } =
             List.map (analyzerRuleToRule >> Rule.filterErrorsForFiles (\file -> List.member file files)) rules
 
 
-getDecoders : RuleConfig -> List (Decoder Comment)
-getDecoders { rules } =
-    List.filterMap analyzerRuleToDecoder rules
+getDecoders : List RuleConfig -> List (Decoder Comment)
+getDecoders =
+    List.concatMap (.rules >> List.filterMap analyzerRuleToDecoder)
+
+
+getComments : List RuleConfig -> List Comment
+getComments =
+    List.concatMap (.rules >> List.map analyzerRuleToComment)
 
 
 makeConfig : List RuleConfig -> List Rule

--- a/tests/AnalyzerTest.elm
+++ b/tests/AnalyzerTest.elm
@@ -53,8 +53,8 @@ allRules =
                                             { calledFrom = calledFrom
                                             , findFunctions = findFunctions
                                             , find = find
-                                            , comment = quickComment name
                                             }
+                                            (quickComment name)
                                         )
                                     )
                         )
@@ -751,8 +751,8 @@ callingFunction param =
                             { calledFrom = Anywhere
                             , findFunctions = [ AnyFromExternalModule [ "Ext", "Sub" ] ]
                             , find = All
-                            , comment = quickComment "Ext.Sub"
                             }
+                            (quickComment "Ext.Sub")
                         )
                     |> Review.Test.expectNoErrors
         , test "should detect imported Basic functions with module name" <|
@@ -774,8 +774,8 @@ callingFunction param =
                                 , FromExternalModule [ "Basics" ] "round"
                                 ]
                             , find = All
-                            , comment = quickComment "basics"
                             }
+                            (quickComment "basics")
                         )
                     |> Review.Test.expectNoErrors
         , test "shouldn't confuse imported Basic functions with module functions" <|
@@ -797,8 +797,8 @@ callingFunction param =
                                 , FromSameModule "round"
                                 ]
                             , find = Some
-                            , comment = quickComment "basics"
                             }
+                            (quickComment "basics")
                         )
                     |> Review.Test.expectGlobalErrors
                         [ TestHelper.createExpectedGlobalError (quickComment "basics") ]

--- a/tests/CommentTest.elm
+++ b/tests/CommentTest.elm
@@ -14,7 +14,7 @@ import Test exposing (Test, describe, test)
 
 tests =
     describe "CommentTest tests"
-        [ aggregateCommentsTest, encoderDecoderTest, makeSummaryTest ]
+        [ aggregateCommentsTest, encoderDecoderTest, makeSummaryTest, toWebsiteCopyPathTest ]
 
 
 fuzzComment : Fuzzer Comment
@@ -129,21 +129,21 @@ aggregateCommentsTest =
                 Expect.equal
                     (Comment.aggregateComments
                         [ essential
-                        , { essential | comment = "a" }
+                        , { essential | path = "a" }
                         , informative
-                        , { celebratory | comment = "a" }
+                        , { celebratory | path = "a" }
                         , actionable
                         , celebratory
-                        , { actionable | comment = "a" }
+                        , { actionable | path = "a" }
                         ]
                     )
                     (Summary "Check the comments for things to fix.\u{202F}🛠 "
                         [ celebratory
-                        , { celebratory | comment = "a" }
+                        , { celebratory | path = "a" }
                         , essential
-                        , { essential | comment = "a" }
+                        , { essential | path = "a" }
                         , actionable
-                        , { actionable | comment = "a" }
+                        , { actionable | path = "a" }
                         , informative
                         , Comment.feedbackComment
                         ]
@@ -168,7 +168,7 @@ makeSummaryTest =
                         )
         , test "common rule comment" <|
             \() ->
-                Comment.makeSummary (List.concatMap RuleConfig.getDecoders [ NoUnused.ruleConfig, Simplify.ruleConfig ])
+                Comment.makeSummary (RuleConfig.getDecoders [ NoUnused.ruleConfig, Simplify.ruleConfig ])
                     "{\"type\":\"review-errors\",\"errors\":[{\"path\":\"src/TwoFer.elm\",\"errors\":[{\"rule\":\"Simplify\",\"message\":\"Unnecessary concatenation with an empty string\",\"ruleLink\":\"https://package.elm-lang.org/packages/jfmengels/elm-review-simplify/2.0.7/Simplify\",\"details\":[\"You should remove the concatenation with the empty string.\"],\"region\":{\"start\":{\"line\":6,\"column\":31},\"end\":{\"line\":6,\"column\":33}},\"fix\":[{\"range\":{\"start\":{\"line\":6,\"column\":31},\"end\":{\"line\":6,\"column\":37}},\"string\":\"\"}],\"formatted\":[{\"string\":\"(fix) \",\"color\":\"#33BBC8\"},{\"string\":\"Simplify\",\"color\":\"#FF0000\",\"href\":\"https://package.elm-lang.org/packages/jfmengels/elm-review-simplify/2.0.7/Simplify\"},\": Unnecessary concatenation with an empty string\\n\\n5|     \\\"One for \\\"\\n6|         ++ Maybe.withDefault (\\\"\\\" ++ \\\"you\\\") name\\n                                 \",{\"string\":\"^^\",\"color\":\"#FF0000\"},\"\\n7|         ++ \\\", one for me.\\\"\\n\\nYou should remove the concatenation with the empty string.\"],\"suppressed\":false,\"originallySuppressed\":false}]}]}"
                     |> Expect.equal
                         (Ok
@@ -188,4 +188,18 @@ makeSummaryTest =
                 Comment.makeSummary []
                     "{\"type\":\"review-errors\",\"errors\":[{\"path\":\"src/TwoFer.elm\",\"errors\":[{\"rule\":\"Simplify\",\"message\":\"Unnecessary concatenation with an empty string\",\"ruleLink\":\"https://package.elm-lang.org/packages/jfmengels/elm-review-simplify/2.0.7/Simplify\",\"details\":[\"You should remove the concatenation with the empty string.\"],\"region\":{\"start\":{\"line\":6,\"column\":31},\"end\":{\"line\":6,\"column\":33}},\"fix\":[{\"range\":{\"start\":{\"line\":6,\"column\":31},\"end\":{\"line\":6,\"column\":37}},\"string\":\"\"}],\"formatted\":[{\"string\":\"(fix) \",\"color\":\"#33BBC8\"},{\"string\":\"Simplify\",\"color\":\"#FF0000\",\"href\":\"https://package.elm-lang.org/packages/jfmengels/elm-review-simplify/2.0.7/Simplify\"},\": Unnecessary concatenation with an empty string\\n\\n5|     \\\"One for \\\"\\n6|         ++ Maybe.withDefault (\\\"\\\" ++ \\\"you\\\") name\\n                                 \",{\"string\":\"^^\",\"color\":\"#FF0000\"},\"\\n7|         ++ \\\", one for me.\\\"\\n\\nYou should remove the concatenation with the empty string.\"],\"suppressed\":false,\"originallySuppressed\":false}]}]}"
                     |> Expect.err
+        ]
+
+
+toWebsiteCopyPathTest : Test
+toWebsiteCopyPathTest =
+    describe "transform Comment into a valid website-copy path"
+        [ test "short path" <|
+            \() ->
+                Comment.toWebsiteCopyPath (Comment "name" "elm.comment" Informative Dict.empty)
+                    |> Expect.equal "analyzer-comments/elm/comment.md"
+        , test "long path" <|
+            \() ->
+                Comment.toWebsiteCopyPath (Comment "name" "elm.something.or.other.comment" Informative Dict.empty)
+                    |> Expect.equal "analyzer-comments/elm/something/or/other/comment.md"
         ]

--- a/tests/Common/NoUnusedTest.elm
+++ b/tests/Common/NoUnusedTest.elm
@@ -12,6 +12,7 @@ import NoUnused.Patterns
 import NoUnused.Variables
 import Review.Rule exposing (Rule)
 import Review.Test
+import RuleConfig
 import Test exposing (Test, describe, test)
 import TestHelper
 
@@ -29,12 +30,7 @@ tests =
 
 rules : List Rule
 rules =
-    [ NoUnused.CustomTypeConstructors.rule []
-    , NoUnused.CustomTypeConstructorArgs.rule
-    , NoUnused.Parameters.rule
-    , NoUnused.Patterns.rule
-    , NoUnused.Variables.rule
-    ]
+    NoUnused.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
 
 
 adequateCode : Test
@@ -73,7 +69,11 @@ type TwoFer = TwoFerUnused
                         ]
         , test "decoder behavior" <|
             \() ->
-                Decode.decodeString NoUnused.customTypeConstructorsDecoder """
+                let
+                    comment =
+                        Comment "NoUnused.CustomTypeConstructors" "elm.common.no_unused.custom_type_constructors" Actionable Dict.empty
+                in
+                Decode.decodeString (NoUnused.makeDecoder comment) """
 {
 "rule": "NoUnused.CustomTypeConstructors",
 "message": "Type constructor `TwoFerUnused` is not used.",
@@ -130,7 +130,11 @@ type TwoFer = TwoFerUnused String
                         ]
         , test "decoder behavior" <|
             \() ->
-                Decode.decodeString NoUnused.customTypeConstructorArgsDecoder """
+                let
+                    comment =
+                        Comment "NoUnused.CustomTypeConstructorArgs" "elm.common.no_unused.custom_type_constructor_args" Actionable Dict.empty
+                in
+                Decode.decodeString (NoUnused.makeDecoder comment) """
 {
 "rule": "NoUnused.CustomTypeConstructorArgs",
 "message": "Argument is never extracted and therefore never used.",
@@ -188,7 +192,11 @@ import Parser.Advanced
                         ]
         , test "decoder behavior" <|
             \() ->
-                Decode.decodeString NoUnused.variablesDecoder """
+                let
+                    comment =
+                        Comment "NoUnused.Variables" "elm.common.no_unused.variables" Actionable Dict.empty
+                in
+                Decode.decodeString (NoUnused.makeDecoder comment) """
 {
 "rule": "NoUnused.Variables",
 "message": "Imported module `Parser.Advanced` is not used",
@@ -258,7 +266,11 @@ unusedParameter unused =
                         ]
         , test "decoder behavior" <|
             \() ->
-                Decode.decodeString NoUnused.parametersDecoder """
+                let
+                    comment =
+                        Comment "NoUnused.Parameters" "elm.common.no_unused.parameters" Actionable Dict.empty
+                in
+                Decode.decodeString (NoUnused.makeDecoder comment) """
 {
 "rule": "NoUnused.Parameters",
 "message": "Parameter `unused` is not used",
@@ -319,7 +331,11 @@ f x =
                         ]
         , test "decoder behavior" <|
             \() ->
-                Decode.decodeString NoUnused.patternsDecoder """
+                let
+                    comment =
+                        Comment "NoUnused.Patterns" "elm.common.no_unused.patterns" Actionable Dict.empty
+                in
+                Decode.decodeString (NoUnused.makeDecoder comment) """
 {
 "rule": "NoUnused.Patterns",
 "message": "Value `something` is not used",

--- a/tests/Common/SimplifyTest.elm
+++ b/tests/Common/SimplifyTest.elm
@@ -60,7 +60,7 @@ one =
                         ]
         , test "decoder behavior" <|
             \() ->
-                Decode.decodeString Common.Simplify.simplifyDecoder """
+                Decode.decodeString (Common.Simplify.simplifyDecoder (Comment "Simplify" "elm.common.simplify" Actionable Dict.empty)) """
 {
 "rule": "Simplify",
 "message": "Unnecessary multiplication by 1",

--- a/tests/Exercise/BettysBikeShopTest.elm
+++ b/tests/Exercise/BettysBikeShopTest.elm
@@ -5,6 +5,7 @@ import Dict
 import Exercise.BettysBikeShop as BettysBikeShop
 import Review.Rule exposing (Rule)
 import Review.Test
+import RuleConfig
 import Test exposing (Test, describe, test)
 import TestHelper
 
@@ -20,7 +21,7 @@ tests =
 
 rules : List Rule
 rules =
-    [ BettysBikeShop.hasFunctionSignatures, BettysBikeShop.importString ]
+    BettysBikeShop.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
 
 
 exemplar : Test
@@ -123,7 +124,7 @@ poundsToString : Float -> String
 poundsToString pounds =
     "£" ++ String.fromFloat pounds
 """
-                    |> Review.Test.run BettysBikeShop.hasFunctionSignatures
+                    |> Review.Test.run (BettysBikeShop.hasFunctionSignatures comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder comment "penceToPounds"
                             |> Review.Test.atExactly { start = { row = 7, column = 1 }, end = { row = 7, column = 14 } }
@@ -143,7 +144,7 @@ penceToPounds pence =
 poundsToString pounds =
     "£" ++ String.fromFloat pounds
 """
-                    |> Review.Test.run BettysBikeShop.hasFunctionSignatures
+                    |> Review.Test.run (BettysBikeShop.hasFunctionSignatures comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder comment "poundsToString"
                             |> Review.Test.atExactly { start = { row = 11, column = 1 }, end = { row = 11, column = 15 } }
@@ -163,7 +164,7 @@ penceToPounds pence =
 poundsToString pounds =
     "£" ++ String.fromFloat pounds
 """
-                    |> Review.Test.run BettysBikeShop.hasFunctionSignatures
+                    |> Review.Test.run (BettysBikeShop.hasFunctionSignatures comment)
                     |> Review.Test.expectErrors
                         -- location of the error is on last function found, but it won't be shown to students anyway
                         [ TestHelper.createExpectedErrorUnder comment "poundsToString"
@@ -188,7 +189,7 @@ poundsToString =
 addPoundsSymbol =
     (++) "£"
 """
-                    |> Review.Test.run BettysBikeShop.hasFunctionSignatures
+                    |> Review.Test.run (BettysBikeShop.hasFunctionSignatures comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder comment "addPoundsSymbol"
                             |> Review.Test.atExactly { start = { row = 15, column = 1 }, end = { row = 15, column = 16 } }
@@ -198,6 +199,10 @@ addPoundsSymbol =
 
 noImportString : Test
 noImportString =
+    let
+        comment =
+            Comment "does not import String" "elm.bettys-bike-shop.import_string" Essential Dict.empty
+    in
     describe "solutions that do no import String" <|
         [ test "without the import String" <|
             \() ->
@@ -212,9 +217,7 @@ poundsToString : Float -> String
 poundsToString pounds =
     "£" ++ String.fromFloat pounds
 """
-                    |> Review.Test.run BettysBikeShop.importString
+                    |> Review.Test.run (BettysBikeShop.importString comment)
                     |> Review.Test.expectGlobalErrors
-                        [ TestHelper.createExpectedGlobalError
-                            (Comment "does not import String" "elm.bettys-bike-shop.import_string" Essential Dict.empty)
-                        ]
+                        [ TestHelper.createExpectedGlobalError comment ]
         ]

--- a/tests/Exercise/BlorkemonCardsTest.elm
+++ b/tests/Exercise/BlorkemonCardsTest.elm
@@ -5,6 +5,7 @@ import Dict
 import Exercise.BlorkemonCards as BlorkemonCards
 import Review.Rule exposing (Rule)
 import Review.Test
+import RuleConfig
 import Test exposing (Test, describe, test)
 import TestHelper
 
@@ -22,11 +23,7 @@ tests =
 
 rules : List Rule
 rules =
-    [ BlorkemonCards.maxPowerUsesMax
-    , BlorkemonCards.sortByMonsterNameUsesSortBy
-    , BlorkemonCards.expectedWinnerUsesCompareShinyPower
-    , BlorkemonCards.expectedWinnerUsesCase
-    ]
+    BlorkemonCards.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
 
 
 exemplar : Test
@@ -153,6 +150,10 @@ expectedWinner card1 card2 =
 
 noMax : Test
 noMax =
+    let
+        comment =
+            Comment "maxPower doesn't use max" "elm.blorkemon-cards.use_max" Essential Dict.empty
+    in
     test "maxPower doesn't use max" <|
         \() ->
             """
@@ -163,14 +164,17 @@ maxPower card1 card2 =
     then card1.power
     else card2.power
 """
-                |> Review.Test.run BlorkemonCards.maxPowerUsesMax
+                |> Review.Test.run (BlorkemonCards.maxPowerUsesMax comment)
                 |> Review.Test.expectErrors
-                    [ TestHelper.createExpectedErrorUnder (Comment "maxPower doesn't use max" "elm.blorkemon-cards.use_max" Essential Dict.empty) "maxPower"
-                    ]
+                    [ TestHelper.createExpectedErrorUnder comment "maxPower" ]
 
 
 noSortBy : Test
 noSortBy =
+    let
+        comment =
+            Comment "sortByMonsterName doesn't use List.sortBy" "elm.blorkemon-cards.use_sort_by" Essential Dict.empty
+    in
     test "sortByMonsterName doesn't use List.sortBy" <|
         \() ->
             """
@@ -187,14 +191,18 @@ sortByMonsterName =
                 GT
         )
 """
-                |> Review.Test.run BlorkemonCards.sortByMonsterNameUsesSortBy
+                |> Review.Test.run (BlorkemonCards.sortByMonsterNameUsesSortBy comment)
                 |> Review.Test.expectErrors
-                    [ TestHelper.createExpectedErrorUnder (Comment "sortByMonsterName doesn't use List.sortBy" "elm.blorkemon-cards.use_sort_by" Essential Dict.empty) "sortByMonsterName"
+                    [ TestHelper.createExpectedErrorUnder comment "sortByMonsterName"
                     ]
 
 
 noCompareShinyPower : Test
 noCompareShinyPower =
+    let
+        comment =
+            Comment "expectedWinner doesn't use compareShinyPower" "elm.blorkemon-cards.use_shiny_power" Essential Dict.empty
+    in
     test "expectedWinner doesn't use compareShinyPower" <|
         \() ->
             """
@@ -211,14 +219,18 @@ expectedWinner card1 card2 =
         GT ->
             card1.monster
 """
-                |> Review.Test.run BlorkemonCards.expectedWinnerUsesCompareShinyPower
+                |> Review.Test.run (BlorkemonCards.expectedWinnerUsesCompareShinyPower comment)
                 |> Review.Test.expectErrors
-                    [ TestHelper.createExpectedErrorUnder (Comment "expectedWinner doesn't use compareShinyPower" "elm.blorkemon-cards.use_shiny_power" Essential Dict.empty) "expectedWinner"
+                    [ TestHelper.createExpectedErrorUnder comment "expectedWinner"
                     ]
 
 
 noCase : Test
 noCase =
+    let
+        comment =
+            Comment "Doesn't use a case expression" "elm.blorkemon-cards.use_case" Essential Dict.empty
+    in
     test "expectedWinner doesn't use a case expression" <|
         \() ->
             """
@@ -234,7 +246,7 @@ expectedWinner card1 card2 =
         else
             card1.monster
 """
-                |> Review.Test.run BlorkemonCards.expectedWinnerUsesCase
+                |> Review.Test.run (BlorkemonCards.expectedWinnerUsesCase comment)
                 |> Review.Test.expectErrors
-                    [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use a case expression" "elm.blorkemon-cards.use_case" Essential Dict.empty) "expectedWinner"
+                    [ TestHelper.createExpectedErrorUnder comment "expectedWinner"
                     ]

--- a/tests/Exercise/MariosMarvellousLasagnaTest.elm
+++ b/tests/Exercise/MariosMarvellousLasagnaTest.elm
@@ -5,6 +5,7 @@ import Dict
 import Exercise.MariosMarvellousLasagna as MariosMarvellousLasagna
 import Review.Rule exposing (Rule)
 import Review.Test
+import RuleConfig
 import Test exposing (Test, describe, test)
 import TestHelper
 
@@ -19,7 +20,7 @@ tests =
 
 rules : List Rule
 rules =
-    [ MariosMarvellousLasagna.usesLet ]
+    MariosMarvellousLasagna.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
 
 
 exemplar : Test
@@ -82,6 +83,10 @@ remainingTimeInMinutes layers minutesSinceStarting =
 
 noLet : Test
 noLet =
+    let
+        comment =
+            Comment "Doesn't use a let expression" "elm.marios-marvellous-lasagna.use_let" Essential Dict.empty
+    in
     test "doesn't use a let expression" <|
         \() ->
             """
@@ -91,8 +96,8 @@ remainingTimeInMinutes : Int -> Int -> Int
 remainingTimeInMinutes layers minutesSinceStarting =
     (2 * layers) + 40 - minutesSinceStarting
 """
-                |> Review.Test.run MariosMarvellousLasagna.usesLet
+                |> Review.Test.run (MariosMarvellousLasagna.usesLet comment)
                 |> Review.Test.expectErrors
-                    [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use a let expression" "elm.marios-marvellous-lasagna.use_let" Essential Dict.empty) "remainingTimeInMinutes"
+                    [ TestHelper.createExpectedErrorUnder comment "remainingTimeInMinutes"
                         |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 23 } }
                     ]

--- a/tests/Exercise/StrainTest.elm
+++ b/tests/Exercise/StrainTest.elm
@@ -5,10 +5,12 @@ import Dict
 import Exercise.Strain as Strain
 import Review.Rule exposing (Rule)
 import Review.Test
+import RuleConfig
 import Test exposing (Test, describe, test)
 import TestHelper
 
 
+tests : Test
 tests =
     describe "StrainTest"
         [ exampleSolution
@@ -19,7 +21,7 @@ tests =
 
 rules : List Rule
 rules =
-    [ Strain.doNotUseFilter ]
+    Strain.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
 
 
 exampleSolution : Test
@@ -111,6 +113,10 @@ consIf predicate value list =
 
 usingFilter : Test
 usingFilter =
+    let
+        comment =
+            Comment "Uses the List module" "elm.strain.do_not_use_filter" Essential Dict.empty
+    in
     describe "solutions that use filter or filterMap" <|
         [ test "using List.filter" <|
             \() ->
@@ -128,10 +134,10 @@ discard : (a -> Bool) -> List a -> List a
 discard predicate =
     List.filter (predicate >> not)
 """
-                    |> Review.Test.run Strain.doNotUseFilter
+                    |> Review.Test.run (Strain.doNotUseFilter comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder
-                            (Comment "Uses the List module" "elm.strain.do_not_use_filter" Essential Dict.empty)
+                            comment
                             "List.filter"
                             |> Review.Test.atExactly { start = { row = 13, column = 5 }, end = { row = 13, column = 16 } }
                         ]
@@ -151,10 +157,10 @@ discard : (a -> Bool) -> List a -> List a
 discard predicate =
     List.filterMap (\\a -> if predicate a then Nothing else Just a)
 """
-                    |> Review.Test.run Strain.doNotUseFilter
+                    |> Review.Test.run (Strain.doNotUseFilter comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder
-                            (Comment "Uses the List module" "elm.strain.do_not_use_filter" Essential Dict.empty)
+                            comment
                             "List.filterMap"
                             |> Review.Test.atExactly { start = { row = 13, column = 5 }, end = { row = 13, column = 19 } }
                         ]
@@ -174,10 +180,10 @@ discard : (a -> Bool) -> List a -> List a
 discard predicate =
     filterMap (\\a -> if predicate a then Nothing else Just a)
 """
-                    |> Review.Test.run Strain.doNotUseFilter
+                    |> Review.Test.run (Strain.doNotUseFilter comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder
-                            (Comment "Uses the List module" "elm.strain.do_not_use_filter" Essential Dict.empty)
+                            comment
                             "filter"
                             |> Review.Test.atExactly { start = { row = 8, column = 5 }, end = { row = 8, column = 11 } }
                         ]
@@ -200,10 +206,10 @@ discard : (a -> Bool) -> List a -> List a
 discard predicate =
     totallyNotFilter (predicate >> not)
 """
-                    |> Review.Test.run Strain.doNotUseFilter
+                    |> Review.Test.run (Strain.doNotUseFilter comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder
-                            (Comment "Uses the List module" "elm.strain.do_not_use_filter" Essential Dict.empty)
+                            comment
                             "filter"
                             |> Review.Test.atExactly { start = { row = 7, column = 3 }, end = { row = 7, column = 9 } }
                         ]

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -5,6 +5,7 @@ import Dict
 import Exercise.TopScorers as TopScorers
 import Review.Rule exposing (Rule)
 import Review.Test
+import RuleConfig
 import Test exposing (Test, describe, test)
 import TestHelper
 
@@ -18,13 +19,7 @@ tests =
 
 rules : List Rule
 rules =
-    [ TopScorers.removeInsignificantPlayersMustUseFilter
-    , TopScorers.resetPlayerGoalCountMustUseInsert
-    , TopScorers.formatPlayersCannotUseSort
-    , TopScorers.combineGamesMustUseMerge
-    , TopScorers.aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer
-    , TopScorers.formatPlayerMustUseWithDefault
-    ]
+    TopScorers.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
 
 
 exemplar : Test
@@ -102,6 +97,10 @@ ruleTests =
     describe "code that violates the rules"
         [ test "should report that Dict.filter must be used" <|
             \() ->
+                let
+                    comment =
+                        Comment "Doesn't use Dict.filter" "elm.top-scorers.use_filter" Essential Dict.empty
+                in
                 """
 module TopScorers exposing (..)
 
@@ -111,13 +110,17 @@ removeInsignificantPlayers goalThreshold playerGoalCounts =
     |> List.filter (\\t -> Tuple.second t >= goalThreshold)
     |> Dict.fromList
             """
-                    |> Review.Test.run TopScorers.removeInsignificantPlayersMustUseFilter
+                    |> Review.Test.run (TopScorers.removeInsignificantPlayersMustUseFilter comment)
                     |> Review.Test.expectErrors
-                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Dict.filter" "elm.top-scorers.use_filter" Essential Dict.empty) "removeInsignificantPlayers"
+                        [ TestHelper.createExpectedErrorUnder comment "removeInsignificantPlayers"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 27 } }
                         ]
         , test "should report that Dict.insert must be used" <|
             \() ->
+                let
+                    comment =
+                        Comment "Doesn't use Dict.insert" "elm.top-scorers.use_insert" Essential Dict.empty
+                in
                 """
 module TopScorers exposing (..)
 
@@ -126,13 +129,17 @@ resetPlayerGoalCount playerName playerGoalCounts =
     playerGoalCounts
     |> Dict.update playerName (\\ _ -> Just 0 )
             """
-                    |> Review.Test.run TopScorers.resetPlayerGoalCountMustUseInsert
+                    |> Review.Test.run (TopScorers.resetPlayerGoalCountMustUseInsert comment)
                     |> Review.Test.expectErrors
-                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Dict.insert" "elm.top-scorers.use_insert" Essential Dict.empty) "resetPlayerGoalCount"
+                        [ TestHelper.createExpectedErrorUnder comment "resetPlayerGoalCount"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 21 } }
                         ]
         , test "should report that List.sort cannot be used" <|
             \() ->
+                let
+                    comment =
+                        Comment "Uses List.sort" "elm.top-scorers.dont_use_sort" Essential Dict.empty
+                in
                 """
 module TopScorers exposing (..)
 
@@ -140,13 +147,17 @@ formatPlayers : Dict PlayerName Int -> String
 formatPlayers players =
     Dict.keys players |> List.sort |> String.join ", "
             """
-                    |> Review.Test.run TopScorers.formatPlayersCannotUseSort
+                    |> Review.Test.run (TopScorers.formatPlayersCannotUseSort comment)
                     |> Review.Test.expectErrors
-                        [ TestHelper.createExpectedErrorUnder (Comment "Uses List.sort" "elm.top-scorers.dont_use_sort" Essential Dict.empty) "List.sort"
+                        [ TestHelper.createExpectedErrorUnder comment "List.sort"
                             |> Review.Test.atExactly { start = { row = 6, column = 26 }, end = { row = 6, column = 35 } }
                         ]
         , test "should report that Dict.merge must be used" <|
             \() ->
+                let
+                    comment =
+                        Comment "Doesn't use Dict.merge" "elm.top-scorers.use_merge" Essential Dict.empty
+                in
                 """
 module TopScorers exposing (..)
 
@@ -156,13 +167,17 @@ combineGames game1 game2 =
     |> Dict.toList
     |> List.foldr (\\(name,score) g -> Dict.update name (update score) g) game2
             """
-                    |> Review.Test.run TopScorers.combineGamesMustUseMerge
+                    |> Review.Test.run (TopScorers.combineGamesMustUseMerge comment)
                     |> Review.Test.expectErrors
-                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Dict.merge" "elm.top-scorers.use_merge" Essential Dict.empty) "combineGames"
+                        [ TestHelper.createExpectedErrorUnder comment "combineGames"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
                         ]
         , test "should report that List.foldl and updateGoalCountForPlayer must be used" <|
             \() ->
+                let
+                    comment =
+                        Comment "Doesn't use List.foldl and updateGoalCountForPlayer" "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty
+                in
                 """
 module TopScorers exposing (..)
 
@@ -183,13 +198,17 @@ aggregateScorers playerNames =
         )
         Dict.empty
             """
-                    |> Review.Test.run TopScorers.aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer
+                    |> Review.Test.run (TopScorers.aggregateScorersMustUseFoldlAndUpdateGoalCountForPlayer comment)
                     |> Review.Test.expectErrors
-                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use List.foldl and updateGoalCountForPlayer" "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty) "aggregateScorers"
+                        [ TestHelper.createExpectedErrorUnder comment "aggregateScorers"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 17 } }
                         ]
         , test "should report that Maybe.withDefault must be used" <|
             \() ->
+                let
+                    comment =
+                        Comment "Doesn't use Maybe.withDefault" "elm.top-scorers.use_withDefault" Essential Dict.empty
+                in
                 """
 module TopScorers exposing (..)
 
@@ -199,9 +218,9 @@ formatPlayer playerName playerGoalCounts =
         Just n  -> playerName ++ ": " ++ String.fromInt n
         Nothing -> playerName ++ ": 0"
             """
-                    |> Review.Test.run TopScorers.formatPlayerMustUseWithDefault
+                    |> Review.Test.run (TopScorers.formatPlayerMustUseWithDefault comment)
                     |> Review.Test.expectErrors
-                        [ TestHelper.createExpectedErrorUnder (Comment "Doesn't use Maybe.withDefault" "elm.top-scorers.use_withDefault" Essential Dict.empty) "formatPlayer"
+                        [ TestHelper.createExpectedErrorUnder comment "formatPlayer"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
                         ]
         ]

--- a/tests/Exercise/TwoFerTest.elm
+++ b/tests/Exercise/TwoFerTest.elm
@@ -5,6 +5,7 @@ import Dict
 import Exercise.TwoFer as TwoFer
 import Review.Rule exposing (Rule)
 import Review.Test
+import RuleConfig
 import Test exposing (Test, describe, test)
 import TestHelper
 
@@ -20,9 +21,7 @@ tests =
 
 rules : List Rule
 rules =
-    [ TwoFer.hasFunctionSignature
-    , TwoFer.usesWithDefault
-    ]
+    TwoFer.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
 
 
 exampleSolution : Test
@@ -78,10 +77,8 @@ twoFer name =
 noFuctionSignature : Test
 noFuctionSignature =
     let
-        error =
-            TestHelper.createExpectedErrorUnder
-                (Comment "has no signature" "elm.two-fer.use_signature" Informative Dict.empty)
-                "twoFer"
+        comment =
+            Comment "has no signature" "elm.two-fer.use_signature" Informative Dict.empty
     in
     describe "solutions without function signatures" <|
         [ test "no function signature" <|
@@ -94,9 +91,9 @@ twoFer name =
         ++ Maybe.withDefault "you" name
         ++ ", one for me."
 """
-                    |> Review.Test.run TwoFer.hasFunctionSignature
+                    |> Review.Test.run (TwoFer.hasFunctionSignature comment)
                     |> Review.Test.expectErrors
-                        [ error
+                        [ TestHelper.createExpectedErrorUnder comment "twoFer"
                             |> Review.Test.atExactly { start = { row = 4, column = 1 }, end = { row = 4, column = 7 } }
                         ]
         , test "commented function signature" <|
@@ -110,9 +107,9 @@ twoFer name =
         ++ Maybe.withDefault "you" name
         ++ ", one for me."
 """
-                    |> Review.Test.run TwoFer.hasFunctionSignature
+                    |> Review.Test.run (TwoFer.hasFunctionSignature comment)
                     |> Review.Test.expectErrors
-                        [ error
+                        [ TestHelper.createExpectedErrorUnder comment "twoFer"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 7 } }
                         ]
         ]
@@ -120,6 +117,10 @@ twoFer name =
 
 noWithDefault : Test
 noWithDefault =
+    let
+        comment =
+            Comment "Doesn't use withDefault" "elm.two-fer.use_withDefault" Informative Dict.empty
+    in
     describe "solutions that don't use withDefault" <|
         [ test "using a case statement" <|
             \() ->
@@ -137,10 +138,10 @@ twoFer name =
                 ++ you
                 ++ ", one for me."
 """
-                    |> Review.Test.run TwoFer.usesWithDefault
+                    |> Review.Test.run (TwoFer.usesWithDefault comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder
-                            (Comment "Doesn't use withDefault" "elm.two-fer.use_withDefault" Informative Dict.empty)
+                            comment
                             "twoFer"
                             |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 7 } }
                         ]
@@ -157,10 +158,10 @@ twoFer name =
         ++ Maybe.Extra.withDefaultLazy (\\() -> "you") name
         ++ ", one for me."
 """
-                    |> Review.Test.run TwoFer.usesWithDefault
+                    |> Review.Test.run (TwoFer.usesWithDefault comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder
-                            (Comment "Doesn't use withDefault" "elm.two-fer.use_withDefault" Informative Dict.empty)
+                            comment
                             "twoFer"
                             |> Review.Test.atExactly { start = { row = 7, column = 1 }, end = { row = 7, column = 7 } }
                         ]


### PR DESCRIPTION
We have been burned before by typos in the comment paths (`elm.blorkemon-cards.use_sort_by`), because they have to match an equivalent file in `website-copy` (`analyzer-comments/elm/blorkemon-cards/use_sort_by.md`).
This PR adds a CI check to make sure that all paths exist.

Of course, that means that all new PRs with new comments will fail until the comments are merged in `website-copy`.

I was only able to do that after a major refactor best explained by this diff

```diff
 type AnalyzerRule
-    = CustomRule Rule
-    | ImportedRule Rule (Decoder Comment)
+    = CustomRule (Comment -> Rule) Comment
+    | ImportedRule Rule (Comment -> Decoder Comment) Comment
```

`Review.Rule` is an opaque type, so it is impossible to extract comments from it, so I had to separate the comments on the top level. I had to do a ton of work to make the refactor, but because this is `Elm` we are talking about, everything worked as soon as it compiled. All of that is the first commit (I recommend reviewing it separately).

Once I did that, I made `Main.elm` spit out the list of paths via `cli.js`, and added a simple script so the CI could check the paths against the repo.