### PR TITLE
Add rules for concept exercise `treasure-factory`

### DIFF
--- a/src/ElmSyntaxHelpers.elm
+++ b/src/ElmSyntaxHelpers.elm
@@ -1,0 +1,50 @@
+module ElmSyntaxHelpers exposing (typeAnnotationsMatch)
+
+import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation(..))
+
+
+typeAnnotationsMatch : Node TypeAnnotation -> Node TypeAnnotation -> Bool
+typeAnnotationsMatch a b =
+    let
+        listsMatchWith f x y =
+            (List.length x == List.length y) && (List.map2 f x y |> List.all identity)
+    in
+    case ( Node.value a, Node.value b ) of
+        ( GenericType aName, GenericType bName ) ->
+            aName == bName
+
+        ( Typed aName aArgs, Typed bName bArgs ) ->
+            (Node.value aName == Node.value bName)
+                && listsMatchWith typeAnnotationsMatch aArgs bArgs
+
+        ( Unit, Unit ) ->
+            True
+
+        ( Tupled aArgs, Tupled bArgs ) ->
+            listsMatchWith typeAnnotationsMatch aArgs bArgs
+
+        ( Record aRecordFields, Record bRecordFields ) ->
+            listsMatchWith
+                (\(Node _ ( aName, aType )) (Node _ ( bName, bType )) ->
+                    (Node.value aName == Node.value bName)
+                        && typeAnnotationsMatch aType bType
+                )
+                aRecordFields
+                bRecordFields
+
+        ( GenericRecord aName (Node _ aRecordFields), GenericRecord bName (Node _ bRecordFields) ) ->
+            (Node.value aName == Node.value bName)
+                && listsMatchWith
+                    (\(Node _ ( aInnerName, aType )) (Node _ ( bInnerName, bType )) ->
+                        (Node.value aInnerName == Node.value bInnerName)
+                            && typeAnnotationsMatch aType bType
+                    )
+                    aRecordFields
+                    bRecordFields
+
+        ( FunctionTypeAnnotation a1 a2, FunctionTypeAnnotation b1 b2 ) ->
+            typeAnnotationsMatch a1 b1 && typeAnnotationsMatch a2 b2
+
+        _ ->
+            False

--- a/src/Exercise/TreasureFactory.elm
+++ b/src/Exercise/TreasureFactory.elm
@@ -1,0 +1,217 @@
+module Exercise.TreasureFactory exposing (makeChestSignatureMatchesStub, makeTreasureChestSignatureMatchesStub, ruleConfig, secureChestSignatureIsCorrect, uniqueTreasuresSignatureIsCorrect)
+
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Elm.Syntax.Declaration as Declaration exposing (Declaration)
+import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Signature exposing (Signature)
+import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation(..))
+import ElmSyntaxHelpers
+import Review.Rule as Rule exposing (Error, Rule)
+import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
+
+
+ruleConfig : RuleConfig
+ruleConfig =
+    { slug = Just "treasure-factory"
+    , restrictToFiles = Just [ "src/TreasureFactory.elm" ]
+    , rules =
+        [ CustomRule makeChestSignatureMatchesStub
+            (Comment "makeChest signature was changed" "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty)
+        , CustomRule makeTreasureChestSignatureMatchesStub
+            (Comment "makeTreasureChest signature was changed" "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty)
+        , CustomRule secureChestSignatureIsCorrect
+            (Comment "secureChest signature is incorrect" "elm.treasure-factory.incorrect_secureChest_signature" Essential Dict.empty)
+        , CustomRule uniqueTreasuresSignatureIsCorrect
+            (Comment "uniqueTreasures signature is incorrect" "elm.treasure-factory.incorrect_uniqueTreasures_signature" Essential Dict.empty)
+        ]
+    }
+
+
+makeChestSignatureMatchesStub : Comment -> Rule
+makeChestSignatureMatchesStub comment =
+    let
+        expectedSignature =
+            { name = Node.empty "makeChest"
+            , typeAnnotation =
+                Node.empty
+                    (FunctionTypeAnnotation
+                        (Node.empty (Typed (Node.empty ( [], "String" )) []))
+                        (Node.empty
+                            (FunctionTypeAnnotation
+                                (Node.empty (GenericType "treasure"))
+                                (Node.empty
+                                    (Typed
+                                        (Node.empty ( [], "Chest" ))
+                                        [ Node.empty (GenericType "treasure")
+                                        , Node.empty (Record [])
+                                        ]
+                                    )
+                                )
+                            )
+                        )
+                    )
+            }
+    in
+    signatureMustBe comment expectedSignature
+
+
+makeTreasureChestSignatureMatchesStub : Comment -> Rule
+makeTreasureChestSignatureMatchesStub comment =
+    let
+        expectedSignature =
+            { name = Node.empty "makeTreasureChest"
+            , typeAnnotation =
+                Node.empty
+                    (FunctionTypeAnnotation
+                        (Node.empty
+                            (Typed
+                                (Node.empty ( [], "Chest" ))
+                                [ Node.empty (GenericType "treasure")
+                                , Node.empty
+                                    (GenericRecord
+                                        (Node.empty "conditions")
+                                        (Node.empty
+                                            [ Node.empty ( Node.empty "securePassword", Node.empty Unit )
+                                            , Node.empty ( Node.empty "uniqueTreasure", Node.empty Unit )
+                                            ]
+                                        )
+                                    )
+                                ]
+                            )
+                        )
+                        (Node.empty
+                            (Typed
+                                (Node.empty ( [], "TreasureChest" ))
+                                [ Node.empty (GenericType "treasure") ]
+                            )
+                        )
+                    )
+            }
+    in
+    signatureMustBe comment expectedSignature
+
+
+secureChestSignatureIsCorrect : Comment -> Rule
+secureChestSignatureIsCorrect comment =
+    let
+        expectedSignature =
+            { name = Node.empty "secureChest"
+            , typeAnnotation =
+                Node.empty
+                    (FunctionTypeAnnotation
+                        (Node.empty
+                            (Typed
+                                (Node.empty ( [], "Chest" ))
+                                [ Node.empty (GenericType "treasure")
+                                , Node.empty (GenericType "conditions")
+                                ]
+                            )
+                        )
+                        (Node.empty
+                            (Typed
+                                (Node.empty ( [], "Maybe" ))
+                                [ Node.empty
+                                    (Typed
+                                        (Node.empty ( [], "Chest" ))
+                                        [ Node.empty (GenericType "treasure")
+                                        , Node.empty
+                                            (GenericRecord
+                                                (Node.empty "conditions")
+                                                (Node.empty
+                                                    [ Node.empty ( Node.empty "securePassword", Node.empty Unit ) ]
+                                                )
+                                            )
+                                        ]
+                                    )
+                                ]
+                            )
+                        )
+                    )
+            }
+    in
+    signatureMustBe comment expectedSignature
+
+
+uniqueTreasuresSignatureIsCorrect : Comment -> Rule
+uniqueTreasuresSignatureIsCorrect comment =
+    let
+        expectedSignature =
+            { name = Node.empty "uniqueTreasures"
+            , typeAnnotation =
+                Node.empty
+                    (FunctionTypeAnnotation
+                        (Node.empty
+                            (Typed
+                                (Node.empty ( [], "List" ))
+                                [ Node.empty
+                                    (Typed
+                                        (Node.empty ( [], "Chest" ))
+                                        [ Node.empty (GenericType "treasure")
+                                        , Node.empty (GenericType "conditions")
+                                        ]
+                                    )
+                                ]
+                            )
+                        )
+                        (Node.empty
+                            (Typed
+                                (Node.empty ( [], "List" ))
+                                [ Node.empty
+                                    (Typed
+                                        (Node.empty ( [], "Chest" ))
+                                        [ Node.empty (GenericType "treasure")
+                                        , Node.empty
+                                            (GenericRecord
+                                                (Node.empty "conditions")
+                                                (Node.empty
+                                                    [ Node.empty
+                                                        ( Node.empty "uniqueTreasure"
+                                                        , Node.empty Unit
+                                                        )
+                                                    ]
+                                                )
+                                            )
+                                        ]
+                                    )
+                                ]
+                            )
+                        )
+                    )
+            }
+    in
+    signatureMustBe comment expectedSignature
+
+
+signatureMustBe : Comment -> Signature -> Rule
+signatureMustBe comment expectedSignature =
+    Rule.newModuleRuleSchema comment.path []
+        |> Rule.withSimpleDeclarationVisitor (hasExpectedSignatureVisitor comment expectedSignature)
+        |> Rule.fromModuleRuleSchema
+
+
+hasExpectedSignatureVisitor : Comment -> Signature -> Node Declaration -> List (Error {})
+hasExpectedSignatureVisitor comment expectedSignature node =
+    case Node.value node of
+        Declaration.FunctionDeclaration { declaration, signature } ->
+            if (declaration |> Node.value |> .name |> Node.value) == Node.value expectedSignature.name then
+                let
+                    error =
+                        [ Comment.createError comment (declaration |> Node.value |> .name |> Node.range) ]
+                in
+                case signature of
+                    Nothing ->
+                        error
+
+                    Just (Node _ { typeAnnotation }) ->
+                        if ElmSyntaxHelpers.typeAnnotationsMatch typeAnnotation expectedSignature.typeAnnotation then
+                            []
+
+                        else
+                            error
+
+            else
+                []
+
+        _ ->
+            []

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -9,6 +9,7 @@ import Exercise.MazeMaker
 import Exercise.Strain
 import Exercise.TopScorers
 import Exercise.TracksOnTracksOnTracks
+import Exercise.TreasureFactory
 import Review.Rule as Rule exposing (Rule)
 import RuleConfig exposing (RuleConfig)
 
@@ -26,6 +27,7 @@ ruleConfigs =
     , Exercise.BlorkemonCards.ruleConfig
     , Exercise.TracksOnTracksOnTracks.ruleConfig
     , Exercise.MazeMaker.ruleConfig
+    , Exercise.TreasureFactory.ruleConfig
 
     -- Practice Exercises
     , Exercise.Strain.ruleConfig

--- a/tests/ElmSyntaxHelpersTest.elm
+++ b/tests/ElmSyntaxHelpersTest.elm
@@ -1,0 +1,80 @@
+module ElmSyntaxHelpersTest exposing (..)
+
+import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation(..))
+import ElmSyntaxHelpers
+import Expect
+import Fuzz exposing (Fuzzer)
+import Test exposing (Test, describe, fuzz, fuzz2, test)
+
+
+typeAnnotationsMatchTests : Test
+typeAnnotationsMatchTests =
+    describe "typeAnnotationsMatch"
+        [ test "ranges are ignored" <|
+            \_ ->
+                let
+                    noRangeUnit =
+                        Node.empty Unit
+
+                    someRangeUnit =
+                        Node { start = { row = 5, column = 1 }, end = { row = 5, column = 16 } } Unit
+                in
+                ElmSyntaxHelpers.typeAnnotationsMatch noRangeUnit someRangeUnit
+                    |> Expect.equal True
+        , fuzz typeAnnotationsFuzzer "a TypeAnnotation matches itself" <|
+            \a ->
+                ElmSyntaxHelpers.typeAnnotationsMatch a a
+                    |> Expect.equal True
+        , fuzz2 typeAnnotationsFuzzer typeAnnotationsFuzzer "only matches equal TypeAnnotations" <|
+            \a b ->
+                ElmSyntaxHelpers.typeAnnotationsMatch a b
+                    |> Expect.equal (a == b)
+        ]
+
+
+typeAnnotationsFuzzer : Fuzzer (Node TypeAnnotation)
+typeAnnotationsFuzzer =
+    let
+        unit =
+            Fuzz.constant Unit
+
+        genericType =
+            Fuzz.map GenericType Fuzz.string
+
+        moduleType =
+            Fuzz.pair (Fuzz.listOfLengthBetween 0 2 Fuzz.string) Fuzz.string
+                |> Fuzz.map Node.empty
+
+        annotation =
+            Fuzz.lazy (\_ -> typeAnnotationsFuzzer)
+
+        list =
+            Fuzz.listOfLengthBetween 0 2 annotation
+
+        typed =
+            Fuzz.map2 Typed moduleType list
+
+        tupled =
+            Fuzz.map Tupled list
+
+        string =
+            Fuzz.map Node.empty Fuzz.string
+
+        recordDefinition =
+            Fuzz.pair string annotation
+                |> Fuzz.map Node.empty
+                |> Fuzz.listOfLengthBetween 0 2
+
+        record =
+            Fuzz.map Record recordDefinition
+
+        genericRecord =
+            Fuzz.map2 GenericRecord string (Fuzz.map Node.empty recordDefinition)
+
+        functionTypeAnnotation =
+            Fuzz.map2 FunctionTypeAnnotation annotation annotation
+    in
+    [ unit, genericType, typed, tupled, record, genericRecord, functionTypeAnnotation ]
+        |> List.map (Fuzz.map Node.empty)
+        |> Fuzz.oneOf

--- a/tests/Exercise/BettysBikeShopTest.elm
+++ b/tests/Exercise/BettysBikeShopTest.elm
@@ -10,6 +10,7 @@ import Test exposing (Test, describe, test)
 import TestHelper
 
 
+tests : Test
 tests =
     describe "BettysBikeShopTest"
         [ exemplar

--- a/tests/Exercise/TreasureFactoryTest.elm
+++ b/tests/Exercise/TreasureFactoryTest.elm
@@ -1,0 +1,253 @@
+module Exercise.TreasureFactoryTest exposing (tests)
+
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Exercise.TreasureFactory as TreasureFactory
+import Review.Rule exposing (Rule)
+import Review.Test
+import RuleConfig
+import Test exposing (Test, describe, test)
+import TestHelper
+
+
+tests : Test
+tests =
+    describe "TreasureFactoryTest"
+        [ exemplar
+        , incorrectMakeChestSignature
+        , incorrectMakeTreasureChest
+        , incorrectSecureChest
+        , incorrectUniqueTreasures
+        ]
+
+
+rules : List Rule
+rules =
+    TreasureFactory.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
+
+
+exemplar : Test
+exemplar =
+    test "should not report anything for the exemplar" <|
+        \() ->
+            TestHelper.expectNoErrorsForRules rules
+                """
+module TreasureFactory exposing (TreasureChest, getTreasure, makeChest, makeTreasureChest, secureChest, uniqueTreasures)
+
+type TreasureChest treasure
+    = TreasureChest String treasure
+
+getTreasure : String -> TreasureChest a -> Maybe a
+getTreasure passwordAttempt (TreasureChest password treasure) =
+    if passwordAttempt == password then
+        Just treasure
+
+    else
+        Nothing
+
+type Chest treasure conditions
+    = Chest String treasure
+
+makeChest : String -> treasure -> Chest treasure {}
+makeChest password treasure =
+    Chest password treasure
+
+secureChest : Chest treasure conditions -> Maybe (Chest treasure { conditions | securePassword : () })
+secureChest (Chest password treasure) =
+    if String.length password >= 8 then
+        Just (Chest password treasure)
+
+    else
+        Nothing
+
+uniqueTreasures : List (Chest treasure conditions) -> List (Chest treasure { conditions | uniqueTreasure : () })
+uniqueTreasures chests =
+    let
+        extractTreasure (Chest _ treasure) =
+            treasure
+
+        treasures =
+            List.map extractTreasure chests
+
+        toUnique : Chest treasure conditions -> Maybe (Chest treasure { conditions | uniqueTreasure : () })
+        toUnique (Chest password treasure) =
+            if unique treasure treasures then
+                Just (Chest password treasure)
+
+            else
+                Nothing
+    in
+    List.filterMap toUnique chests
+
+
+unique : a -> List a -> Bool
+unique element list =
+    list
+        |> List.filter (\\el -> el == element)
+        |> List.length
+        |> (==) 1
+
+makeTreasureChest : Chest treasure { conditions | securePassword : (), uniqueTreasure : () } -> TreasureChest treasure
+makeTreasureChest (Chest password treasure) =
+    TreasureChest password treasure
+"""
+
+
+incorrectMakeChestSignature : Test
+incorrectMakeChestSignature =
+    let
+        comment =
+            Comment "makeChest signature was changed" "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty
+    in
+    describe "solutions with modified makeChest signature" <|
+        [ test "no signature" <|
+            \() ->
+                """
+module TreasureFactory exposing (..)
+
+makeChest password treasure = Chest password treasure
+"""
+                    |> Review.Test.run (TreasureFactory.makeChestSignatureMatchesStub comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "makeChest" ]
+        , test "type argument changed" <|
+            \() ->
+                """
+module TreasureFactory exposing (..)
+
+makeChest : String -> treasure -> Chest treasure somethingWrong
+makeChest password treasure =
+    Chest password treasure
+"""
+                    |> Review.Test.run (TreasureFactory.makeChestSignatureMatchesStub comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "makeChest"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 10 } }
+                        ]
+        , test "type alias" <|
+            \() ->
+                """
+module TreasureFactory exposing (..)
+
+type alias Password = String
+
+makeChest : Password -> treasure -> Chest treasure {}
+makeChest password treasure =
+    Chest password treasure
+"""
+                    |> Review.Test.run (TreasureFactory.makeChestSignatureMatchesStub comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "makeChest"
+                            |> Review.Test.atExactly { start = { row = 7, column = 1 }, end = { row = 7, column = 10 } }
+                        ]
+        ]
+
+
+incorrectMakeTreasureChest : Test
+incorrectMakeTreasureChest =
+    let
+        comment =
+            Comment "makeTreasureChest signature was changed" "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty
+    in
+    describe "solutions with modified makeTreasureChest signature" <|
+        [ test "no signature" <|
+            \() ->
+                """
+module TreasureFactory exposing (..)
+
+makeTreasureChest (Chest password treasure) = TreasureChest password treasure
+"""
+                    |> Review.Test.run (TreasureFactory.makeTreasureChestSignatureMatchesStub comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "makeTreasureChest" ]
+        , test "something changed" <|
+            \() ->
+                """
+module TreasureFactory exposing (..)
+
+makeTreasureChest : Chest treasure { conditions | securePassword : (), uniqueTreasure : Bool } -> TreasureChest treasure
+makeTreasureChest (Chest password treasure) =
+    TreasureChest password treasure
+"""
+                    |> Review.Test.run (TreasureFactory.makeTreasureChestSignatureMatchesStub comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "makeTreasureChest"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 18 } }
+                        ]
+        ]
+
+
+incorrectSecureChest : Test
+incorrectSecureChest =
+    let
+        comment =
+            Comment "secureChest signature is incorrect" "elm.treasure-factory.incorrect_secureChest_signature" Essential Dict.empty
+    in
+    describe "solutions with modified secureChest signature" <|
+        [ test "no signature" <|
+            \() ->
+                """
+module TreasureFactory exposing (..)
+
+secureChest (Chest password treasure) =
+    if String.length password >= 8 then
+        Just (Chest password treasure)
+
+    else
+        Nothing
+"""
+                    |> Review.Test.run (TreasureFactory.secureChestSignatureIsCorrect comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "secureChest" ]
+        , test "something changed" <|
+            \() ->
+                """
+module TreasureFactory exposing (..)
+
+secureChest : Chest tReAsUrE conditions -> Maybe (Chest treasure { conditions | securePassword : () })
+secureChest (Chest password treasure) =
+    if String.length password >= 8 then
+        Just (Chest password treasure)
+
+    else
+        Nothing
+"""
+                    |> Review.Test.run (TreasureFactory.secureChestSignatureIsCorrect comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "secureChest"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 12 } }
+                        ]
+        ]
+
+
+incorrectUniqueTreasures : Test
+incorrectUniqueTreasures =
+    let
+        comment =
+            Comment "uniqueTreasures signature is incorrect" "elm.treasure-factory.incorrect_uniqueTreasures_signature" Essential Dict.empty
+    in
+    describe "solutions with modified uniqueTreasures signature" <|
+        [ test "no signature" <|
+            \() ->
+                """
+module TreasureFactory exposing (..)
+
+uniqueTreasures chests = []
+"""
+                    |> Review.Test.run (TreasureFactory.uniqueTreasuresSignatureIsCorrect comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "uniqueTreasures" ]
+        , test "something changed" <|
+            \() ->
+                """
+module TreasureFactory exposing (..)
+
+uniqueTreasures : List (Chest treasure conditions) -> List (Chest treasure conditions)
+uniqueTreasures chests = []
+"""
+                    |> Review.Test.run (TreasureFactory.uniqueTreasuresSignatureIsCorrect comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "uniqueTreasures"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 16 } }
+                        ]
+        ]


### PR DESCRIPTION
Closes #57

[Sister PR here](https://github.com/exercism/website-copy/pull/2285).
The way to specify signatures is super verbose, but I think it's still the best way to do it.