### PR TITLE
Add rule for concept exercise `valentines-day`

### DIFF
--- a/src/Exercise/ValentinesDay.elm
+++ b/src/Exercise/ValentinesDay.elm
@@ -1,0 +1,27 @@
+module Exercise.ValentinesDay exposing (ruleConfig, usesCase)
+
+import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Review.Rule exposing (Rule)
+import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
+
+
+ruleConfig : RuleConfig
+ruleConfig =
+    { slug = Just "valentines-day"
+    , restrictToFiles = Just [ "src/ValentinesDay.elm" ]
+    , rules =
+        [ CustomRule usesCase
+            (Comment "Doesn't use a case expression" "elm.valentines-day.use_case" Essential Dict.empty)
+        ]
+    }
+
+
+usesCase : Comment -> Rule
+usesCase =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "rateActivity"
+        , findFunctions = [ CaseBlock ]
+        , find = Some
+        }

--- a/src/Exercise/ValentinesDay.elm
+++ b/src/Exercise/ValentinesDay.elm
@@ -13,7 +13,7 @@ ruleConfig =
     , restrictToFiles = Just [ "src/ValentinesDay.elm" ]
     , rules =
         [ CustomRule usesCase
-            (Comment "Doesn't use a case expression" "elm.valentines-day.use_case" Essential Dict.empty)
+            (Comment "Doesn't use a case expression" "elm.valentines-day.use_case_statement" Essential Dict.empty)
         ]
     }
 

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -9,6 +9,7 @@ import Exercise.MazeMaker
 import Exercise.Strain
 import Exercise.TopScorers
 import Exercise.TracksOnTracksOnTracks
+import Exercise.ValentinesDay
 import Review.Rule as Rule exposing (Rule)
 import RuleConfig exposing (RuleConfig)
 
@@ -26,6 +27,7 @@ ruleConfigs =
     , Exercise.BlorkemonCards.ruleConfig
     , Exercise.TracksOnTracksOnTracks.ruleConfig
     , Exercise.MazeMaker.ruleConfig
+    , Exercise.ValentinesDay.ruleConfig
 
     -- Practice Exercises
     , Exercise.Strain.ruleConfig

--- a/tests/Exercise/ValentinesDayTest.elm
+++ b/tests/Exercise/ValentinesDayTest.elm
@@ -73,7 +73,7 @@ noCase : Test
 noCase =
     let
         comment =
-            Comment "Doesn't use a case expression" "elm.valentines-day.use_case" Essential Dict.empty
+            Comment "Doesn't use a case expression" "elm.valentines-day.use_case_statement" Essential Dict.empty
     in
     test "doesn't use a case expression" <|
         \() ->

--- a/tests/Exercise/ValentinesDayTest.elm
+++ b/tests/Exercise/ValentinesDayTest.elm
@@ -1,0 +1,116 @@
+module Exercise.ValentinesDayTest exposing (tests)
+
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Exercise.ValentinesDay as ValentinesDay
+import Review.Rule exposing (Rule)
+import Review.Test
+import RuleConfig
+import Test exposing (Test, describe, test)
+import TestHelper
+
+
+tests : Test
+tests =
+    describe "ValentinesDayTest"
+        [ exemplar
+        , noCase
+        ]
+
+
+rules : List Rule
+rules =
+    ValentinesDay.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
+
+
+exemplar : Test
+exemplar =
+    test "should not report anything for the exemplar" <|
+        \() ->
+            TestHelper.expectNoErrorsForRules rules
+                """
+module ValentinesDay exposing (..)
+
+type Approval
+    = Yes
+    | No
+    | Maybe
+
+type Cuisine
+    = Korean
+    | Turkish
+
+type Genre
+    = Crime
+    | Horror
+    | Romance
+    | Thriller
+
+type Activity
+    = BoardGame
+    | Chill
+    | Movie Genre
+    | Restaurant Cuisine
+
+rateActivity : Activity -> Approval
+rateActivity activity =
+    case activity of
+        Restaurant Korean ->
+            Yes
+
+        Restaurant Turkish ->
+            Maybe
+
+        Movie Romance ->
+            Yes
+
+        _ ->
+            No
+"""
+
+
+noCase : Test
+noCase =
+    let
+        comment =
+            Comment "Doesn't use a case expression" "elm.valentines-day.use_case" Essential Dict.empty
+    in
+    test "doesn't use a case expression" <|
+        \() ->
+            """
+module ValentinesDay exposing (..)
+
+type Approval
+    = Yes
+    | No
+    | Maybe
+
+type Cuisine
+    = Korean
+    | Turkish
+
+type Genre
+    = Crime
+    | Horror
+    | Romance
+    | Thriller
+
+type Activity
+    = BoardGame
+    | Chill
+    | Movie Genre
+    | Restaurant Cuisine
+
+rateActivity activity =
+    if (activity == Movie Romance) || (activity == Restaurant Korean) then
+        Yes
+
+    else if activity == Restaurant Turkish then
+        Maybe
+
+    else
+        No
+"""
+                |> Review.Test.run (ValentinesDay.usesCase comment)
+                |> Review.Test.expectErrors
+                    [ TestHelper.createExpectedErrorUnder comment "rateActivity" ]


### PR DESCRIPTION
Closes #18 

[Sister PR here](https://github.com/exercism/website-copy/pull/2286).

I picked this one because I thought that the analyzer couldn't detect `case` statements but... It can already :p