### PR TITLE
Add common rule for all exercises: no `Debug` functions

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -10,6 +10,7 @@
             "elm/json": "1.1.3",
             "elm-community/list-extra": "8.7.0",
             "jfmengels/elm-review": "2.13.1",
+            "jfmengels/elm-review-debug": "1.0.8",
             "jfmengels/elm-review-simplify": "2.1.2",
             "jfmengels/elm-review-unused": "1.2.0",
             "stil4m/elm-syntax": "7.3.2"

--- a/review/elm.json
+++ b/review/elm.json
@@ -8,6 +8,7 @@
         "direct": {
             "elm/core": "1.0.5",
             "jfmengels/elm-review": "2.13.1",
+            "jfmengels/elm-review-debug": "1.0.8",
             "jfmengels/elm-review-simplify": "2.1.2",
             "jfmengels/elm-review-unused": "1.2.0",
             "stil4m/elm-syntax": "7.3.2"

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -1,5 +1,7 @@
 module ReviewConfig exposing (config)
 
+import NoDebug.Log
+import NoDebug.TodoOrToString
 import NoUnused.CustomTypeConstructorArgs
 import NoUnused.CustomTypeConstructors
 import NoUnused.Dependencies
@@ -8,9 +10,6 @@ import NoUnused.Modules
 import NoUnused.Parameters
 import NoUnused.Patterns
 import NoUnused.Variables
-import NoDebug.Log
-import NoDebug.TodoOrToString
-
 import Review.Rule exposing (Rule)
 import Simplify
 

--- a/review/src/ReviewConfig.elm
+++ b/review/src/ReviewConfig.elm
@@ -8,6 +8,9 @@ import NoUnused.Modules
 import NoUnused.Parameters
 import NoUnused.Patterns
 import NoUnused.Variables
+import NoDebug.Log
+import NoDebug.TodoOrToString
+
 import Review.Rule exposing (Rule)
 import Simplify
 
@@ -23,4 +26,6 @@ config =
     , NoUnused.Exports.rule |> Review.Rule.ignoreErrorsForDirectories [ "tests/" ]
     , NoUnused.Dependencies.rule
     , Simplify.rule Simplify.defaults
+    , NoDebug.Log.rule
+    , NoDebug.TodoOrToString.rule
     ]

--- a/src/Common/NoDebug.elm
+++ b/src/Common/NoDebug.elm
@@ -1,0 +1,47 @@
+module Common.NoDebug exposing (noDebugDecoder, ruleConfig)
+
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Json.Decode as Decode exposing (Decoder)
+import NoDebug.Log
+import NoDebug.TodoOrToString
+import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
+
+
+
+{-
+
+   Rule source code and tests:
+       https://github.com/jfmengels/elm-review-debug
+
+-}
+
+
+ruleConfig : RuleConfig
+ruleConfig =
+    { slug = Nothing
+    , restrictToFiles = Nothing
+    , rules =
+        [ ImportedRule NoDebug.Log.rule
+            noDebugDecoder
+            (Comment "NoDebug.Log" "elm.common.common.no_debug" Actionable Dict.empty)
+        , ImportedRule NoDebug.TodoOrToString.rule
+            noDebugDecoder
+            (Comment "NoDebug.TodoOrToString" "elm.common.common.no_debug" Actionable Dict.empty)
+        ]
+    }
+
+
+noDebugDecoder : Comment -> Decoder Comment
+noDebugDecoder comment =
+    let
+        toComment : String -> Decoder Comment
+        toComment errorRule =
+            if errorRule == "NoDebug.TodoOrToString" || errorRule == "NoDebug.Log" then
+                Decode.succeed comment
+
+            else
+                Decode.fail "not NoDebug rule"
+    in
+    Decode.field "rule" Decode.string
+        |> Decode.andThen toComment

--- a/src/Common/NoDebug.elm
+++ b/src/Common/NoDebug.elm
@@ -24,10 +24,10 @@ ruleConfig =
     , rules =
         [ ImportedRule NoDebug.Log.rule
             noDebugDecoder
-            (Comment "NoDebug.Log" "elm.common.common.no_debug" Actionable Dict.empty)
+            (Comment "NoDebug.Log" "elm.common.no_debug" Actionable Dict.empty)
         , ImportedRule NoDebug.TodoOrToString.rule
             noDebugDecoder
-            (Comment "NoDebug.TodoOrToString" "elm.common.common.no_debug" Actionable Dict.empty)
+            (Comment "NoDebug.TodoOrToString" "elm.common.no_debug" Actionable Dict.empty)
         ]
     }
 

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -1,5 +1,6 @@
 module ReviewConfig exposing (config, ruleConfigs)
 
+import Common.NoDebug
 import Common.NoUnused
 import Common.Simplify
 import Exercise.BettysBikeShop
@@ -22,6 +23,7 @@ ruleConfigs =
     [ -- Common Rules
       Common.NoUnused.ruleConfig
     , Common.Simplify.ruleConfig
+    , Common.NoDebug.ruleConfig
 
     -- Concept Exercises
     , Exercise.BettysBikeShop.ruleConfig

--- a/tests/Common/NoDebugTest.elm
+++ b/tests/Common/NoDebugTest.elm
@@ -72,7 +72,7 @@ twoFer name =
             \() ->
                 let
                     comment =
-                        Comment "NoDebug.Log" "elm.common.common.no_debug" Actionable Dict.empty
+                        Comment "NoDebug.Log" "elm.common.no_debug" Actionable Dict.empty
                 in
                 Decode.decodeString (Common.NoDebug.noDebugDecoder comment) """
 {
@@ -161,7 +161,7 @@ twoFer name =
             \() ->
                 let
                     comment =
-                        Comment "NoDebug.TodoOrToString" "elm.common.common.no_debug" Actionable Dict.empty
+                        Comment "NoDebug.TodoOrToString" "elm.common.no_debug" Actionable Dict.empty
                 in
                 Decode.decodeString (Common.NoDebug.noDebugDecoder comment) """
 {
@@ -228,7 +228,7 @@ twoFer name =
             \() ->
                 let
                     comment =
-                        Comment "NoDebug.TodoOrToString" "elm.common.common.no_debug" Actionable Dict.empty
+                        Comment "NoDebug.TodoOrToString" "elm.common.no_debug" Actionable Dict.empty
                 in
                 Decode.decodeString (Common.NoDebug.noDebugDecoder comment) """
 {

--- a/tests/Common/NoDebugTest.elm
+++ b/tests/Common/NoDebugTest.elm
@@ -1,0 +1,269 @@
+module Common.NoDebugTest exposing (tests)
+
+import Comment exposing (Comment, CommentType(..))
+import Common.NoDebug
+import Dict
+import Expect
+import Json.Decode as Decode
+import NoDebug.Log
+import NoDebug.TodoOrToString
+import Review.Rule exposing (Rule)
+import Review.Test
+import RuleConfig
+import Test exposing (Test, describe, test)
+import TestHelper
+
+
+tests : Test
+tests =
+    describe "NoDebugTest"
+        [ noDebug
+        , withDebugLog
+        , withDebugTodo
+        , withDebugToString
+        ]
+
+
+rules : List Rule
+rules =
+    Common.NoDebug.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
+
+
+noDebug : Test
+noDebug =
+    test "should not report anything for adequate code" <|
+        \() ->
+            TestHelper.expectNoErrorsForRules rules
+                """
+module TwoFer exposing (twoFer)
+
+twoFer : Maybe String -> String
+twoFer name =
+    "One for "
+        ++ Maybe.withDefault "you" name
+        ++ ", one for me."
+"""
+
+
+withDebugLog : Test
+withDebugLog =
+    describe "detects the presence of a Debug.log"
+        [ test "imported rule works" <|
+            \() ->
+                """
+module TwoFer exposing (twoFer)
+
+twoFer : Maybe String -> String
+twoFer name =
+        "One for "
+            ++ Maybe.withDefault "you" (Debug.log "name" name)
+            ++ ", one for me."
+"""
+                    |> Review.Test.run NoDebug.Log.rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Remove the use of `Debug.log` before shipping to production"
+                            , details = [ "`Debug.log` is useful when developing, but is not meant to be shipped to production or published in a package. I suggest removing its use before committing and attempting to push to production." ]
+                            , under = "Debug.log"
+                            }
+                            |> Review.Test.whenFixed "\nmodule TwoFer exposing (twoFer)\n\ntwoFer : Maybe String -> String\ntwoFer name =\n        \"One for \"\n            ++ Maybe.withDefault \"you\" (name)\n            ++ \", one for me.\"\n"
+                        ]
+        , test "decoder behavior" <|
+            \() ->
+                let
+                    comment =
+                        Comment "NoDebug.Log" "elm.common.common.no_debug" Actionable Dict.empty
+                in
+                Decode.decodeString (Common.NoDebug.noDebugDecoder comment) """
+{
+  "rule": "NoDebug.Log",
+  "message": "Remove the use of `Debug.log` before shipping to production",
+  "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-debug/1.0.8/NoDebug-Log",
+  "details": [
+    "`Debug.log` is useful when developing, but is not meant to be shipped to production or published in a package. I suggest removing its use before committing and attempting to push to production."
+  ],
+  "region": {
+    "start": {
+      "line": 53,
+      "column": 37
+    },
+    "end": {
+      "line": 53,
+      "column": 46
+    }
+  },
+  "fix": [
+    {
+      "range": {
+        "start": {
+          "line": 53,
+          "column": 37
+        },
+        "end": {
+          "line": 53,
+          "column": 54
+        }
+      },
+      "string": ""
+    }
+  ],
+  "formatted": [
+    {
+      "string": "(fix) ",
+      "color": "#33BBC8"
+    },
+    {
+      "string": "NoDebug.Log",
+      "color": "#FF0000",
+      "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-debug/1.0.8/NoDebug-Log"
+    },
+    ": Remove the use of `Debug.log` before shipping to production\\n\\n52|     \\"One for \\"\\n53|         ++ Maybe.withDefault \\"you\\" (Debug.log \\"name\\" name)\\n                                        ",
+    {
+      "string": "^^^^^^^^^",
+      "color": "#FF0000"
+    },
+    "\\n54|         ++ \\", one for me.\\"\\n\\n`Debug.log` is useful when developing, but is not meant to be shipped to production or published in a package. I suggest removing its use before committing and attempting to push to production."
+  ],
+  "suppressed": false,
+  "originallySuppressed": false
+}
+"""
+                    |> Expect.equal (Ok comment)
+        ]
+
+
+withDebugTodo : Test
+withDebugTodo =
+    describe "detects the presence of a Debug.todo"
+        [ test "imported rule works" <|
+            \() ->
+                """
+module TwoFer exposing (twoFer)
+
+twoFer : Maybe String -> String
+twoFer name =
+    if name == Just "Cedd" then
+        Debug.todo "think of something funny later"
+    else
+        "One for "
+            ++ Maybe.withDefault "you" name
+            ++ ", one for me."
+"""
+                    |> Review.Test.run NoDebug.TodoOrToString.rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Remove the use of `Debug.todo` before shipping to production"
+                            , details = [ "`Debug.todo` can be useful when developing, but is not meant to be shipped to production or published in a package. I suggest removing its use before committing and attempting to push to production." ]
+                            , under = "Debug.todo"
+                            }
+                        ]
+        , test "decoder behavior" <|
+            \() ->
+                let
+                    comment =
+                        Comment "NoDebug.TodoOrToString" "elm.common.common.no_debug" Actionable Dict.empty
+                in
+                Decode.decodeString (Common.NoDebug.noDebugDecoder comment) """
+{
+    "rule": "NoDebug.TodoOrToString",
+    "message": "Remove the use of `Debug.todo` before shipping to production",
+    "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-debug/1.0.8/NoDebug-TodoOrToString",
+    "details": [
+    "`Debug.todo` can be useful when developing, but is not meant to be shipped to production or published in a package. I suggest removing its use before committing and attempting to push to production."
+    ],
+    "region": {
+    "start": {
+        "line": 48,
+        "column": 12
+    },
+    "end": {
+        "line": 48,
+        "column": 22
+    }
+    },
+    "formatted": [
+    {
+        "string": "NoDebug.TodoOrToString",
+        "color": "#FF0000",
+        "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-debug/1.0.8/NoDebug-TodoOrToString"
+    },
+    ": Remove the use of `Debug.todo` before shipping to production\\n47|         |> Debug.todo \\"think of something funny later\\"\\n",
+    {
+        "string": "^^^^^^^^^^",
+        "color": "#FF0000"
+    },
+    "`Debug.todo` can be useful when developing, but is not meant to be shipped to production or published in a package. I suggest removing its use before committing and attempting to push to production."
+    ],
+    "suppressed": false,
+    "originallySuppressed": false
+}
+    """
+                    |> Expect.equal (Ok comment)
+        ]
+
+
+withDebugToString : Test
+withDebugToString =
+    describe "detects the presence of a Debug.toString"
+        [ test "imported rule works" <|
+            \() ->
+                """
+module TwoFer exposing (twoFer)
+
+twoFer : Maybe String -> String
+twoFer name =
+        "One for "
+            ++ Debug.toString name
+            ++ ", one for me."
+"""
+                    |> Review.Test.run NoDebug.TodoOrToString.rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "Remove the use of `Debug.toString` before shipping to production"
+                            , details = [ "`Debug.toString` can be useful when developing, but is not meant to be shipped to production or published in a package. I suggest removing its use before committing and attempting to push to production." ]
+                            , under = "Debug.toString"
+                            }
+                        ]
+        , test "decoder behavior" <|
+            \() ->
+                let
+                    comment =
+                        Comment "NoDebug.TodoOrToString" "elm.common.common.no_debug" Actionable Dict.empty
+                in
+                Decode.decodeString (Common.NoDebug.noDebugDecoder comment) """
+{
+  "rule": "NoDebug.TodoOrToString",
+  "message": "Remove the use of `Debug.toString` before shipping to production",
+  "ruleLink": "https://package.elm-lang.org/packages/jfmengels/elm-review-debug/1.0.8/NoDebug-TodoOrToString",
+  "details": [
+    "`Debug.toString` can be useful when developing, but is not meant to be shipped to production or published in a package. I suggest removing its use before committing and attempting to push to production."
+  ],
+  "region": {
+    "start": {
+      "line": 53,
+      "column": 12
+    },
+    "end": {
+      "line": 53,
+      "column": 26
+    }
+  },
+  "formatted": [
+    {
+      "string": "NoDebug.TodoOrToString",
+      "color": "#FF0000",
+      "href": "https://package.elm-lang.org/packages/jfmengels/elm-review-debug/1.0.8/NoDebug-TodoOrToString"
+    },
+    ": Remove the use of `Debug.toString` before shipping to production\\n\\n52|     \\"One for \\"\\n53|         ++ Debug.toString name\\n               ",
+    {
+      "string": "^^^^^^^^^^^^^^",
+      "color": "#FF0000"
+    },
+    "\\n54|         ++ \\", one for me.\\"\\n\\n`Debug.toString` can be useful when developing, but is not meant to be shipped to production or published in a package. I suggest removing its use before committing and attempting to push to production."
+  ],
+  "suppressed": false,
+  "originallySuppressed": false
+}
+"""
+                    |> Expect.equal (Ok comment)
+        ]

--- a/tests/Common/NoUnusedTest.elm
+++ b/tests/Common/NoUnusedTest.elm
@@ -17,6 +17,7 @@ import Test exposing (Test, describe, test)
 import TestHelper
 
 
+tests : Test
 tests =
     describe "NoUnusedTest"
         [ adequateCode

--- a/tests/Common/SimplifyTest.elm
+++ b/tests/Common/SimplifyTest.elm
@@ -12,6 +12,7 @@ import Test exposing (Test, describe, test)
 import TestHelper
 
 
+tests : Test
 tests =
     describe "SimplifyTest"
         [ adequateCode, simplify ]


### PR DESCRIPTION
[Sister PR here](https://github.com/exercism/website-copy/pull/2291).
Part of #13.

This check is meant to be a rule checked against all solutions, and warns students against publishing solution with `Debug` functions in them.

There are two more common rules that I feel are appropriate after this one:
- Disallow `-- TODO` comments (some stubs have this, sometimes students don't remove them, but it's just noise)
- Comment on variable names not in camelCase, since it's such a strong standard in Elm

Anything else from the list on the issue is not as clear to me and would need discussion.