### PR TITLE
Add rules for concept exercise `ticket-please`

### DIFF
--- a/src/Analyzer.elm
+++ b/src/Analyzer.elm
@@ -72,6 +72,21 @@ type CalledExpression
     | LambdaWithPattern Pattern
 
 
+{-| Patterns that can be searched for, either in function arguments or in expression that support them.
+
+`Record` is for records: `let {a, b} = rec in ...`.
+
+`Tuple` is for tuples: `let (a, b) = pair in ...`.
+
+`Ignore` is for the wild card: `let _ = ignored in ...`.
+
+`Named` is for constructors: `let Just x = maybeX in ...`.
+
+`As` is for assigning a variable to a pattern: `let Just ({a, b} as rec) = maybeRec in ...`.
+
+`String` is for strings: `let Just "x" = maybeX in ...`.
+
+-}
 type Pattern
     = Record
     | Tuple

--- a/src/Analyzer.elm
+++ b/src/Analyzer.elm
@@ -78,6 +78,7 @@ type Pattern
     | Ignore
     | Named
     | As
+    | String
 
 
 {-| Type of search.
@@ -449,6 +450,9 @@ matchPattern (Node range pattern) foundExpression =
             foundAt range foundExpression
 
         ( Pattern.AsPattern _ _, Just As ) ->
+            foundAt range foundExpression
+
+        ( Pattern.StringPattern _, Just String ) ->
             foundAt range foundExpression
 
         -- already found expression/pattern, or pattern that doesn't match

--- a/src/Analyzer.elm
+++ b/src/Analyzer.elm
@@ -432,66 +432,54 @@ matchExpression (Node range expression) foundExpression =
 
 
 matchArgumentPattern : Node Pattern.Pattern -> FoundExpression -> FoundExpression
-matchArgumentPattern (Node range elmSyntaxPattern) foundExpression =
+matchArgumentPattern node foundExpression =
     case foundExpression of
         NotFound (ArgumentWithPattern pattern) ->
-            if matchPattern elmSyntaxPattern pattern then
-                foundAt range foundExpression
-
-            else
-                foundExpression
+            matchPattern node pattern foundExpression
 
         _ ->
             foundExpression
 
 
 matchExpressionPattern : Node Pattern.Pattern -> FoundExpression -> FoundExpression
-matchExpressionPattern (Node range elmSyntaxPattern) foundExpression =
-    let
-        checkPattern pattern =
-            if matchPattern elmSyntaxPattern pattern then
-                foundAt range foundExpression
-
-            else
-                foundExpression
-    in
+matchExpressionPattern node foundExpression =
     case foundExpression of
         NotFound (LetWithPattern pattern) ->
-            checkPattern pattern
+            matchPattern node pattern foundExpression
 
         NotFound (CaseWithPattern pattern) ->
-            checkPattern pattern
+            matchPattern node pattern foundExpression
 
         NotFound (LambdaWithPattern pattern) ->
-            checkPattern pattern
+            matchPattern node pattern foundExpression
 
         _ ->
             foundExpression
 
 
-matchPattern : Pattern.Pattern -> Pattern -> Bool
-matchPattern elmSyntaxPattern pattern =
+matchPattern : Node Pattern.Pattern -> Pattern -> FoundExpression -> FoundExpression
+matchPattern (Node range elmSyntaxPattern) pattern =
     case ( elmSyntaxPattern, pattern ) of
         ( Pattern.RecordPattern _, Record ) ->
-            True
+            foundAt range
 
         ( Pattern.TuplePattern _, Tuple ) ->
-            True
+            foundAt range
 
         ( Pattern.AllPattern, Ignore ) ->
-            True
+            foundAt range
 
         ( Pattern.NamedPattern _ _, Named ) ->
-            True
+            foundAt range
 
         ( Pattern.AsPattern _ _, As ) ->
-            True
+            foundAt range
 
         ( Pattern.StringPattern _, String ) ->
-            True
+            foundAt range
 
         _ ->
-            False
+            identity
 
 
 foundAt : Range -> FoundExpression -> FoundExpression

--- a/src/Analyzer.elm
+++ b/src/Analyzer.elm
@@ -72,7 +72,7 @@ type CalledExpression
     | LambdaWithPattern Pattern
 
 
-{-| Patterns that can be searched for, either in function arguments or in expression that support them.
+{-| Patterns that can be searched for, either in function arguments or in expressions that support them.
 
 `Record` is for records: `let {a, b} = rec in ...`.
 

--- a/src/ElmSyntaxHelpers.elm
+++ b/src/ElmSyntaxHelpers.elm
@@ -1,6 +1,7 @@
-module ElmSyntaxHelpers exposing (hasGenericRecord, typeAnnotationsMatch)
+module ElmSyntaxHelpers exposing (hasGenericRecord, traversePattern, typeAnnotationsMatch)
 
 import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Pattern exposing (Pattern(..))
 import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation(..))
 
 
@@ -73,3 +74,52 @@ hasGenericRecord annotation =
 
         Unit ->
             False
+
+
+traversePattern : Node Pattern -> List (Node Pattern)
+traversePattern pattern =
+    case Node.value pattern of
+        AllPattern ->
+            [ pattern ]
+
+        UnitPattern ->
+            [ pattern ]
+
+        CharPattern _ ->
+            [ pattern ]
+
+        StringPattern _ ->
+            [ pattern ]
+
+        IntPattern _ ->
+            [ pattern ]
+
+        HexPattern _ ->
+            [ pattern ]
+
+        FloatPattern _ ->
+            [ pattern ]
+
+        VarPattern _ ->
+            [ pattern ]
+
+        RecordPattern _ ->
+            [ pattern ]
+
+        AsPattern a _ ->
+            pattern :: traversePattern a
+
+        ParenthesizedPattern a ->
+            pattern :: traversePattern a
+
+        UnConsPattern a b ->
+            pattern :: traversePattern a ++ traversePattern b
+
+        TuplePattern patterns ->
+            pattern :: List.concatMap traversePattern patterns
+
+        ListPattern patterns ->
+            pattern :: List.concatMap traversePattern patterns
+
+        NamedPattern _ patterns ->
+            pattern :: List.concatMap traversePattern patterns

--- a/src/Exercise/Bandwagoner.elm
+++ b/src/Exercise/Bandwagoner.elm
@@ -39,7 +39,7 @@ rootForTeamUsesPatternMatchingInArgument : Comment -> Rule
 rootForTeamUsesPatternMatchingInArgument =
     Analyzer.functionCalls
         { calledFrom = TopFunction "rootForTeam"
-        , findExpressions = [ PatternInArgument Record ]
+        , findExpressions = [ ArgumentWithPattern Record ]
         , find = Some
         }
 

--- a/src/Exercise/Bandwagoner.elm
+++ b/src/Exercise/Bandwagoner.elm
@@ -1,6 +1,6 @@
 module Exercise.Bandwagoner exposing (replaceCoachUsesRecordUpdateSyntax, rootForTeamHasExtensibleRecordSignature, rootForTeamUsesPatternMatchingInArgument, ruleConfig)
 
-import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..), Pattern(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
@@ -35,6 +35,15 @@ replaceCoachUsesRecordUpdateSyntax =
         }
 
 
+rootForTeamUsesPatternMatchingInArgument : Comment -> Rule
+rootForTeamUsesPatternMatchingInArgument =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "rootForTeam"
+        , findExpressions = [ PatternInArgument Record ]
+        , find = Some
+        }
+
+
 rootForTeamHasExtensibleRecordSignature : Comment -> Rule
 rootForTeamHasExtensibleRecordSignature comment =
     Rule.newModuleRuleSchema comment.path []
@@ -61,32 +70,6 @@ hasExtensibleRecordSignatureVisitor comment functionName node =
 
                         else
                             error
-
-            else
-                []
-
-        _ ->
-            []
-
-
-rootForTeamUsesPatternMatchingInArgument : Comment -> Rule
-rootForTeamUsesPatternMatchingInArgument comment =
-    Rule.newModuleRuleSchema comment.path []
-        |> Rule.withSimpleDeclarationVisitor (usesPaternMatchingInArg comment "rootForTeam")
-        |> Rule.fromModuleRuleSchema
-
-
-usesPaternMatchingInArg : Comment -> String -> Node Declaration -> List (Error {})
-usesPaternMatchingInArg comment functionName node =
-    case Node.value node of
-        Declaration.FunctionDeclaration { declaration } ->
-            if (declaration |> Node.value |> .name |> Node.value) == functionName then
-                case declaration |> Node.value |> .arguments of
-                    [ Node _ (RecordPattern _) ] ->
-                        []
-
-                    _ ->
-                        [ Comment.createError comment (declaration |> Node.value |> .name |> Node.range) ]
 
             else
                 []

--- a/src/Exercise/Bandwagoner.elm
+++ b/src/Exercise/Bandwagoner.elm
@@ -1,6 +1,6 @@
 module Exercise.Bandwagoner exposing (replaceCoachUsesRecordUpdateSyntax, rootForTeamHasExtensibleRecordSignature, rootForTeamUsesPatternMatchingInArgument, ruleConfig)
 
-import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
@@ -30,7 +30,7 @@ replaceCoachUsesRecordUpdateSyntax : Comment -> Rule
 replaceCoachUsesRecordUpdateSyntax =
     Analyzer.functionCalls
         { calledFrom = TopFunction "replaceCoach"
-        , findFunctions = [ RecordUpdate ]
+        , findExpressions = [ RecordUpdate ]
         , find = Some
         }
 

--- a/src/Exercise/BlorkemonCards.elm
+++ b/src/Exercise/BlorkemonCards.elm
@@ -1,6 +1,6 @@
 module Exercise.BlorkemonCards exposing (..)
 
-import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Review.Rule exposing (Rule)
@@ -28,7 +28,7 @@ maxPowerUsesMax : Comment -> Rule
 maxPowerUsesMax =
     Analyzer.functionCalls
         { calledFrom = TopFunction "maxPower"
-        , findFunctions = [ FromExternalModule [ "Basics" ] "max" ]
+        , findExpressions = [ FromExternalModule [ "Basics" ] "max" ]
         , find = Some
         }
 
@@ -37,7 +37,7 @@ sortByMonsterNameUsesSortBy : Comment -> Rule
 sortByMonsterNameUsesSortBy =
     Analyzer.functionCalls
         { calledFrom = TopFunction "sortByMonsterName"
-        , findFunctions = [ FromExternalModule [ "List" ] "sortBy" ]
+        , findExpressions = [ FromExternalModule [ "List" ] "sortBy" ]
         , find = Some
         }
 
@@ -46,7 +46,7 @@ expectedWinnerUsesCompareShinyPower : Comment -> Rule
 expectedWinnerUsesCompareShinyPower =
     Analyzer.functionCalls
         { calledFrom = TopFunction "expectedWinner"
-        , findFunctions = [ FromSameModule "compareShinyPower" ]
+        , findExpressions = [ FromSameModule "compareShinyPower" ]
         , find = Some
         }
 
@@ -55,6 +55,6 @@ expectedWinnerUsesCase : Comment -> Rule
 expectedWinnerUsesCase =
     Analyzer.functionCalls
         { calledFrom = TopFunction "expectedWinner"
-        , findFunctions = [ CaseBlock ]
+        , findExpressions = [ CaseBlock ]
         , find = Some
         }

--- a/src/Exercise/CustomSet.elm
+++ b/src/Exercise/CustomSet.elm
@@ -1,6 +1,6 @@
 module Exercise.CustomSet exposing (doNotUseSetModule, ruleConfig)
 
-import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Review.Rule exposing (Rule)
@@ -22,6 +22,6 @@ doNotUseSetModule : Comment -> Rule
 doNotUseSetModule =
     Analyzer.functionCalls
         { calledFrom = Anywhere
-        , findFunctions = [ AnyFromExternalModule [ "Set" ] ]
+        , findExpressions = [ AnyFromExternalModule [ "Set" ] ]
         , find = None
         }

--- a/src/Exercise/ListOps.elm
+++ b/src/Exercise/ListOps.elm
@@ -1,6 +1,6 @@
 module Exercise.ListOps exposing (doNotUseListModule, ruleConfig)
 
-import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Review.Rule exposing (Rule)
@@ -22,6 +22,6 @@ doNotUseListModule : Comment -> Rule
 doNotUseListModule =
     Analyzer.functionCalls
         { calledFrom = Anywhere
-        , findFunctions = [ AnyFromExternalModule [ "List" ] ]
+        , findExpressions = [ AnyFromExternalModule [ "List" ] ]
         , find = None
         }

--- a/src/Exercise/MariosMarvellousLasagna.elm
+++ b/src/Exercise/MariosMarvellousLasagna.elm
@@ -1,6 +1,6 @@
 module Exercise.MariosMarvellousLasagna exposing (ruleConfig, usesLet)
 
-import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Review.Rule exposing (Rule)
@@ -24,6 +24,6 @@ usesLet : Comment -> Rule
 usesLet =
     Analyzer.functionCalls
         { calledFrom = TopFunction "remainingTimeInMinutes"
-        , findFunctions = [ LetBlock ]
+        , findExpressions = [ LetBlock ]
         , find = Some
         }

--- a/src/Exercise/MazeMaker.elm
+++ b/src/Exercise/MazeMaker.elm
@@ -1,6 +1,6 @@
 module Exercise.MazeMaker exposing (mazeOfDepthUsesDeadendRoomAndBranch, mazeOfDepthUsesMazeOfDepth, mazeUsesDeadendRoomAndBranch, mazeUsesMaze, roomUsesTreasure, ruleConfig)
 
-import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Review.Rule exposing (Rule)
@@ -30,7 +30,7 @@ roomUsesTreasure : Comment -> Rule
 roomUsesTreasure =
     Analyzer.functionCalls
         { calledFrom = TopFunction "room"
-        , findFunctions = [ FromSameModule "treasure" ]
+        , findExpressions = [ FromSameModule "treasure" ]
         , find = Some
         }
 
@@ -39,7 +39,7 @@ mazeUsesDeadendRoomAndBranch : Comment -> Rule
 mazeUsesDeadendRoomAndBranch =
     Analyzer.functionCalls
         { calledFrom = TopFunction "maze"
-        , findFunctions = [ FromSameModule "deadend", FromSameModule "room", FromSameModule "branch" ]
+        , findExpressions = [ FromSameModule "deadend", FromSameModule "room", FromSameModule "branch" ]
         , find = All
         }
 
@@ -48,7 +48,7 @@ mazeUsesMaze : Comment -> Rule
 mazeUsesMaze =
     Analyzer.functionCalls
         { calledFrom = TopFunction "maze"
-        , findFunctions = [ FromSameModule "maze" ]
+        , findExpressions = [ FromSameModule "maze" ]
         , find = Some
         }
 
@@ -57,7 +57,7 @@ mazeOfDepthUsesDeadendRoomAndBranch : Comment -> Rule
 mazeOfDepthUsesDeadendRoomAndBranch =
     Analyzer.functionCalls
         { calledFrom = TopFunction "mazeOfDepth"
-        , findFunctions = [ FromSameModule "deadend", FromSameModule "room", FromSameModule "branch" ]
+        , findExpressions = [ FromSameModule "deadend", FromSameModule "room", FromSameModule "branch" ]
         , find = All
         }
 
@@ -66,6 +66,6 @@ mazeOfDepthUsesMazeOfDepth : Comment -> Rule
 mazeOfDepthUsesMazeOfDepth =
     Analyzer.functionCalls
         { calledFrom = TopFunction "mazeOfDepth"
-        , findFunctions = [ FromSameModule "mazeOfDepth" ]
+        , findExpressions = [ FromSameModule "mazeOfDepth" ]
         , find = Some
         }

--- a/src/Exercise/Strain.elm
+++ b/src/Exercise/Strain.elm
@@ -1,6 +1,6 @@
 module Exercise.Strain exposing (doNotUseFilter, ruleConfig)
 
-import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Review.Rule exposing (Rule)
@@ -22,6 +22,6 @@ doNotUseFilter : Comment -> Rule
 doNotUseFilter =
     Analyzer.functionCalls
         { calledFrom = Anywhere
-        , findFunctions = [ FromExternalModule [ "List" ] "filter", FromExternalModule [ "List" ] "filterMap" ]
+        , findExpressions = [ FromExternalModule [ "List" ] "filter", FromExternalModule [ "List" ] "filterMap" ]
         , find = None
         }

--- a/src/Exercise/TicketPlease.elm
+++ b/src/Exercise/TicketPlease.elm
@@ -1,0 +1,115 @@
+module Exercise.TicketPlease exposing
+    ( assignTicketToArgumentShouldUseIgnore
+    , assignTicketToArgumentShouldUseNamedRecordAndAs
+    , assignTicketUsesRecordUpdate
+    , assignedToDevTeamArgumentDestructureInCase
+    , assignedToDevTeamArgumentShouldUseNamedAndRecord
+    , emptyCommentArgumentShouldUseTupleAndIgnore
+    , numberOfCreatorCommentsArgumentShouldUseNamedAndRecord
+    , numberOfCreatorCommentsDestructuresTupleInLetAndLambda
+    , ruleConfig
+    )
+
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..), Pattern(..))
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Elm.Syntax.Pattern exposing (Pattern(..))
+import Review.Rule exposing (Rule)
+import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
+
+
+ruleConfig : RuleConfig
+ruleConfig =
+    { slug = Just "ticket-please"
+    , restrictToFiles = Just [ "src/TicketPlease.elm" ]
+    , rules =
+        [ CustomRule emptyCommentArgumentShouldUseTupleAndIgnore
+            (Comment "emptyComment argument doesn't destructure a tuple and wild card" "elm.ticket-please.destructure_emptyComment_argument" Essential Dict.empty)
+        , CustomRule numberOfCreatorCommentsArgumentShouldUseNamedAndRecord
+            (Comment "numberOfCreatorComments argument doesn't destructure a record in a named pattern" "elm.ticket-please.destructure_numberOfCreatorComments_argument" Essential Dict.empty)
+        , CustomRule numberOfCreatorCommentsDestructuresTupleInLetAndLambda
+            (Comment "numberOfCreatorComments doesn't destructure in let and lambda" "elm.ticket-please.destructure_numberOfCreatorComments_expressions" Essential Dict.empty)
+        , CustomRule assignedToDevTeamArgumentShouldUseNamedAndRecord
+            (Comment "assignedToDevTeam argument doesn't destructure a record in a named pattern" "elm.ticket-please.destructure_assignedToDevTeam_argument" Essential Dict.empty)
+        , CustomRule assignedToDevTeamArgumentDestructureInCase
+            (Comment "assignedToDevTeam argument doesn't destructure in a case block" "elm.ticket-please.destructure_assignedToDevTeam_expressions" Essential Dict.empty)
+        , CustomRule assignTicketToArgumentShouldUseNamedRecordAndAs
+            (Comment "assignTicketTo argument doesn't destructure a record in a named pattern using as" "elm.ticket-please.destructure_assignTicketTo_argument" Essential Dict.empty)
+        , CustomRule assignTicketToArgumentShouldUseIgnore
+            (Comment "assignTicketTo argument doesn't ignore cases" "elm.ticket-please.assignTicketTo_ignore_cases" Actionable Dict.empty)
+        , CustomRule assignTicketUsesRecordUpdate
+            (Comment "assignTicketTo doesn't use the record update syntax" "elm.ticket-please.assignTicketTo_use_record_update" Actionable Dict.empty)
+        ]
+    }
+
+
+emptyCommentArgumentShouldUseTupleAndIgnore : Comment -> Rule
+emptyCommentArgumentShouldUseTupleAndIgnore =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "emptyComment"
+        , findExpressions = [ ArgumentWithPattern Tuple, ArgumentWithPattern Ignore ]
+        , find = All
+        }
+
+
+numberOfCreatorCommentsArgumentShouldUseNamedAndRecord : Comment -> Rule
+numberOfCreatorCommentsArgumentShouldUseNamedAndRecord =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "numberOfCreatorComments"
+        , findExpressions = [ ArgumentWithPattern Named, ArgumentWithPattern Record ]
+        , find = All
+        }
+
+
+numberOfCreatorCommentsDestructuresTupleInLetAndLambda : Comment -> Rule
+numberOfCreatorCommentsDestructuresTupleInLetAndLambda =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "numberOfCreatorComments"
+        , findExpressions = [ LetWithPattern Tuple, LambdaWithPattern Tuple ]
+        , find = All
+        }
+
+
+assignedToDevTeamArgumentShouldUseNamedAndRecord : Comment -> Rule
+assignedToDevTeamArgumentShouldUseNamedAndRecord =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "assignedToDevTeam"
+        , findExpressions = [ ArgumentWithPattern Named, ArgumentWithPattern Record ]
+        , find = All
+        }
+
+
+assignedToDevTeamArgumentDestructureInCase : Comment -> Rule
+assignedToDevTeamArgumentDestructureInCase =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "assignedToDevTeam"
+        , findExpressions = [ CaseWithPattern Named, CaseWithPattern String ]
+        , find = All
+        }
+
+
+assignTicketToArgumentShouldUseNamedRecordAndAs : Comment -> Rule
+assignTicketToArgumentShouldUseNamedRecordAndAs =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "assignTicketTo"
+        , findExpressions = [ ArgumentWithPattern Named, ArgumentWithPattern Record, ArgumentWithPattern As ]
+        , find = All
+        }
+
+
+assignTicketToArgumentShouldUseIgnore : Comment -> Rule
+assignTicketToArgumentShouldUseIgnore =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "assignTicketTo"
+        , findExpressions = [ CaseWithPattern Ignore ]
+        , find = All
+        }
+
+
+assignTicketUsesRecordUpdate : Comment -> Rule
+assignTicketUsesRecordUpdate =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "assignTicketTo"
+        , findExpressions = [ RecordUpdate ]
+        , find = All
+        }

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -1,6 +1,6 @@
 module Exercise.TopScorers exposing (..)
 
-import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Review.Rule exposing (Rule)
@@ -34,7 +34,7 @@ removeInsignificantPlayersMustUseFilter : Comment -> Rule
 removeInsignificantPlayersMustUseFilter =
     Analyzer.functionCalls
         { calledFrom = TopFunction "removeInsignificantPlayers"
-        , findFunctions = [ FromExternalModule [ "Dict" ] "filter" ]
+        , findExpressions = [ FromExternalModule [ "Dict" ] "filter" ]
         , find = Some
         }
 
@@ -43,7 +43,7 @@ resetPlayerGoalCountMustUseInsert : Comment -> Rule
 resetPlayerGoalCountMustUseInsert =
     Analyzer.functionCalls
         { calledFrom = TopFunction "resetPlayerGoalCount"
-        , findFunctions = [ FromExternalModule [ "Dict" ] "insert" ]
+        , findExpressions = [ FromExternalModule [ "Dict" ] "insert" ]
         , find = Some
         }
 
@@ -52,7 +52,7 @@ formatPlayersCannotUseSort : Comment -> Rule
 formatPlayersCannotUseSort =
     Analyzer.functionCalls
         { calledFrom = TopFunction "formatPlayers"
-        , findFunctions = [ FromExternalModule [ "List" ] "sort" ]
+        , findExpressions = [ FromExternalModule [ "List" ] "sort" ]
         , find = None
         }
 
@@ -61,7 +61,7 @@ combineGamesMustUseMerge : Comment -> Rule
 combineGamesMustUseMerge =
     Analyzer.functionCalls
         { calledFrom = TopFunction "combineGames"
-        , findFunctions = [ FromExternalModule [ "Dict" ] "merge" ]
+        , findExpressions = [ FromExternalModule [ "Dict" ] "merge" ]
         , find = Some
         }
 
@@ -70,7 +70,7 @@ aggregateScorersMustUseUpdateGoalCountForPlayer : Comment -> Rule
 aggregateScorersMustUseUpdateGoalCountForPlayer =
     Analyzer.functionCalls
         { calledFrom = TopFunction "aggregateScorers"
-        , findFunctions = [ FromSameModule "updateGoalCountForPlayer" ]
+        , findExpressions = [ FromSameModule "updateGoalCountForPlayer" ]
         , find = All
         }
 
@@ -79,7 +79,7 @@ aggregateScorersMustUseFold : Comment -> Rule
 aggregateScorersMustUseFold =
     Analyzer.functionCalls
         { calledFrom = TopFunction "aggregateScorers"
-        , findFunctions = [ FromExternalModule [ "List" ] "foldl", FromExternalModule [ "List" ] "foldr" ]
+        , findExpressions = [ FromExternalModule [ "List" ] "foldl", FromExternalModule [ "List" ] "foldr" ]
         , find = Some
         }
 
@@ -88,6 +88,6 @@ formatPlayerMustUseWithDefault : Comment -> Rule
 formatPlayerMustUseWithDefault =
     Analyzer.functionCalls
         { calledFrom = TopFunction "formatPlayer"
-        , findFunctions = [ FromExternalModule [ "Maybe" ] "withDefault" ]
+        , findExpressions = [ FromExternalModule [ "Maybe" ] "withDefault" ]
         , find = Some
         }

--- a/src/Exercise/TracksOnTracksOnTracks.elm
+++ b/src/Exercise/TracksOnTracksOnTracks.elm
@@ -1,6 +1,6 @@
 module Exercise.TracksOnTracksOnTracks exposing (addLanguageUsesCons, countLanguagesUsesLength, excitingListUsesCase, reverseListUsesReverse, ruleConfig)
 
-import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Review.Rule exposing (Rule)
@@ -28,7 +28,7 @@ addLanguageUsesCons : Comment -> Rule
 addLanguageUsesCons =
     Analyzer.functionCalls
         { calledFrom = TopFunction "addLanguage"
-        , findFunctions = [ Operator "::" ]
+        , findExpressions = [ Operator "::" ]
         , find = Some
         }
 
@@ -37,7 +37,7 @@ countLanguagesUsesLength : Comment -> Rule
 countLanguagesUsesLength =
     Analyzer.functionCalls
         { calledFrom = TopFunction "countLanguages"
-        , findFunctions = [ FromExternalModule [ "List" ] "length" ]
+        , findExpressions = [ FromExternalModule [ "List" ] "length" ]
         , find = Some
         }
 
@@ -46,7 +46,7 @@ reverseListUsesReverse : Comment -> Rule
 reverseListUsesReverse =
     Analyzer.functionCalls
         { calledFrom = TopFunction "reverseList"
-        , findFunctions = [ FromExternalModule [ "List" ] "reverse" ]
+        , findExpressions = [ FromExternalModule [ "List" ] "reverse" ]
         , find = Some
         }
 
@@ -55,6 +55,6 @@ excitingListUsesCase : Comment -> Rule
 excitingListUsesCase =
     Analyzer.functionCalls
         { calledFrom = TopFunction "excitingList"
-        , findFunctions = [ CaseBlock ]
+        , findExpressions = [ CaseBlock ]
         , find = Some
         }

--- a/src/Exercise/TwoFer.elm
+++ b/src/Exercise/TwoFer.elm
@@ -1,6 +1,6 @@
 module Exercise.TwoFer exposing (hasFunctionSignature, ruleConfig, usesWithDefault)
 
-import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
@@ -49,6 +49,6 @@ usesWithDefault : Comment -> Rule
 usesWithDefault =
     Analyzer.functionCalls
         { calledFrom = TopFunction "twoFer"
-        , findFunctions = [ FromExternalModule [ "Maybe" ] "withDefault" ]
+        , findExpressions = [ FromExternalModule [ "Maybe" ] "withDefault" ]
         , find = All
         }

--- a/src/Exercise/ValentinesDay.elm
+++ b/src/Exercise/ValentinesDay.elm
@@ -1,6 +1,6 @@
 module Exercise.ValentinesDay exposing (ruleConfig, usesCase)
 
-import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Review.Rule exposing (Rule)
@@ -22,6 +22,6 @@ usesCase : Comment -> Rule
 usesCase =
     Analyzer.functionCalls
         { calledFrom = TopFunction "rateActivity"
-        , findFunctions = [ CaseBlock ]
+        , findExpressions = [ CaseBlock ]
         , find = Some
         }

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -9,6 +9,7 @@ import Exercise.CustomSet
 import Exercise.MariosMarvellousLasagna
 import Exercise.MazeMaker
 import Exercise.Strain
+import Exercise.TicketPlease
 import Exercise.TopScorers
 import Exercise.TracksOnTracksOnTracks
 import Exercise.TreasureFactory
@@ -34,6 +35,7 @@ ruleConfigs =
     , Exercise.TreasureFactory.ruleConfig
     , Exercise.ValentinesDay.ruleConfig
     , Exercise.Bandwagoner.ruleConfig
+    , Exercise.TicketPlease.ruleConfig
 
     -- Practice Exercises
     , Exercise.Strain.ruleConfig

--- a/tests/AnalyzerTest.elm
+++ b/tests/AnalyzerTest.elm
@@ -1,6 +1,6 @@
 module AnalyzerTest exposing (tests)
 
-import Analyzer exposing (CalledFrom(..), CalledFunction(..), Find(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict exposing (Dict)
 import Review.Rule exposing (Rule)
@@ -12,7 +12,7 @@ import TestHelper
 tests : Test
 tests =
     describe "AnalyzerTest tests"
-        [ calledFromTest, findFunctionsTest, findTest, indirectCallTest ]
+        [ calledFromTest, findExpressionsTest, findTest, indirectCallTest ]
 
 
 allRules : Dict String Rule
@@ -43,7 +43,7 @@ allRules =
             (\( calledFromName, calledFrom ) ->
                 calling
                     |> List.concatMap
-                        (\( findFunctionName, findFunctions ) ->
+                        (\( findFunctionName, findExpressions ) ->
                             finding
                                 |> List.map
                                     (\( findName, find ) ->
@@ -54,7 +54,7 @@ allRules =
                                         ( name
                                         , Analyzer.functionCalls
                                             { calledFrom = calledFrom
-                                            , findFunctions = findFunctions
+                                            , findExpressions = findExpressions
                                             , find = find
                                             }
                                             (quickComment name)
@@ -282,8 +282,8 @@ callingFunction param =
         ]
 
 
-findFunctionsTest : Test
-findFunctionsTest =
+findExpressionsTest : Test
+findExpressionsTest =
     let
         extRule =
             "calling function, Ext._, all"
@@ -828,7 +828,7 @@ callingFunction param =
                     |> Review.Test.run
                         (Analyzer.functionCalls
                             { calledFrom = Anywhere
-                            , findFunctions = [ AnyFromExternalModule [ "Ext", "Sub" ] ]
+                            , findExpressions = [ AnyFromExternalModule [ "Ext", "Sub" ] ]
                             , find = All
                             }
                             (quickComment "Ext.Sub")
@@ -848,7 +848,7 @@ callingFunction param =
                     |> Review.Test.run
                         (Analyzer.functionCalls
                             { calledFrom = Anywhere
-                            , findFunctions =
+                            , findExpressions =
                                 [ FromExternalModule [ "Basics" ] "toFloat"
                                 , FromExternalModule [ "Basics" ] "round"
                                 ]
@@ -871,7 +871,7 @@ callingFunction param =
                     |> Review.Test.run
                         (Analyzer.functionCalls
                             { calledFrom = Anywhere
-                            , findFunctions =
+                            , findExpressions =
                                 [ FromSameModule "toFloat"
                                 , FromSameModule "round"
                                 ]

--- a/tests/AnalyzerTest.elm
+++ b/tests/AnalyzerTest.elm
@@ -35,7 +35,7 @@ allRules =
             , ( "case", [ CaseBlock ] )
             , ( "recordUpdate", [ RecordUpdate ] )
             , ( "pipe", [ Operator "|>" ] )
-            , ( "arg", [ ArgumentWithPattern Record, ArgumentWithPattern Tuple, ArgumentWithPattern Ignore, ArgumentWithPattern Named, ArgumentWithPattern As ] )
+            , ( "arg", [ ArgumentWithPattern Record, ArgumentWithPattern Tuple, ArgumentWithPattern Ignore, ArgumentWithPattern Named, ArgumentWithPattern As, ArgumentWithPattern String ] )
             , ( "patterns", [ LetWithPattern Tuple, CaseWithPattern Ignore, LambdaWithPattern Record ] )
             , ( "Ext._ + Ext.ext", [ AnyFromExternalModule [ "Ext" ], FromExternalModule [ "Ext" ] "ext" ] )
             , ( "Ext._ + internal", [ AnyFromExternalModule [ "Ext" ], FromSameModule "internal" ] )
@@ -909,7 +909,7 @@ module A exposing (..)
 
 import Ext
 
-callingFunction { a, b } (c, d) _ (Named e) (f as g) =
+callingFunction { a, b } (c, d) _ (Named "e") (f as g) =
   param
   |> Ext.other
   |> internal
@@ -923,7 +923,7 @@ module A exposing (..)
 
 import Ext
 
-callingFunction   ((Named (_, { a, b } as e)), f)=
+callingFunction   ((Named (_, { a, b } as e)), "f")=
   param
   |> Ext.other
   |> internal
@@ -945,7 +945,7 @@ callingFunction param =
 helperFunction1 x =
   helperFunction2 x
 
-helperFunction2 { a, b } (c, d) _ (Named e) (f as g) =
+helperFunction2 { a, b } (c, d) _ (Named "e") (f as g) =
   0
 """
                     |> Review.Test.run (getRule allRule)
@@ -957,7 +957,7 @@ module A exposing (..)
 
 import Ext
 
-wrongCallingFunction { a, b } (c, d) _ (Named e) (f as g) =
+wrongCallingFunction { a, b } (c, d) _ (Named "e") (f as g) =
   param
   |> Ext.other
   |> internal
@@ -974,7 +974,7 @@ import Ext
 
 callingFunction =
   let
-    someInternalFunction { a, b } (c, d) _ (Named e) (f as g) =
+    someInternalFunction { a, b } (c, d) _ (Named "e") (f as g) =
       0
   in
   param
@@ -991,7 +991,7 @@ module A exposing (..)
 
 import Ext
 
-callingFunction missing (c, d) _ (Named e) (f as g) =
+callingFunction missing (c, d) _ (Named "e") (f as g) =
   param
   |> Ext.other
   |> internal
@@ -1006,7 +1006,7 @@ module A exposing (..)
 
 import Ext
 
-callingFunction { a, b } missing _ (Named e) (f as g) =
+callingFunction { a, b } missing _ (Named "e") (f as g) =
   param
   |> Ext.other
   |> internal
@@ -1021,7 +1021,7 @@ module A exposing (..)
 
 import Ext
 
-callingFunction { a, b } (c, d) missing (Named e) (f as g) =
+callingFunction { a, b } (c, d) missing (Named "e") (f as g) =
   param
   |> Ext.other
   |> internal
@@ -1051,7 +1051,22 @@ module A exposing (..)
 
 import Ext
 
-callingFunction { a, b } (c, d) _ (Named e) missing =
+callingFunction { a, b } (c, d) _ (Named "e") missing =
+  param
+  |> Ext.other
+  |> internal
+"""
+                    |> Review.Test.run (getRule allRule)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder (quickComment allRule) "callingFunction" ]
+        , test "missing string" <|
+            \() ->
+                """
+module A exposing (..)
+
+import Ext
+
+callingFunction { a, b } (c, d) _ (Named missing) (f as g) =
   param
   |> Ext.other
   |> internal
@@ -1066,7 +1081,7 @@ module A exposing (..)
 
 import Ext
 
-callingFunction { a, b } (c, d) _ (Named e) (f as g) =
+callingFunction { a, b } (c, d) _ (Named "e") (f as g) =
   param
   |> Ext.other
   |> internal
@@ -1086,7 +1101,7 @@ dallingFunction { a, b } (c, d)  =
   |> internal
 
 
-otherFunction _ (Named e) (f as g) =
+otherFunction _ (Named "e") (f as g) =
   param
   |> Ext.other
   |> internal

--- a/tests/AnalyzerTest.elm
+++ b/tests/AnalyzerTest.elm
@@ -1199,6 +1199,22 @@ callingFunction (a, b) _ { x, y } =
                     |> Review.Test.run (getRule allRule)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder (quickComment allRule) "callingFunction" ]
+        , test "doesn't match patterns in other blocks" <|
+            \() ->
+                """
+module A exposing (..)
+
+callingFunction param =
+  let
+      {a, b} = param
+  in
+  case a of
+      a ->
+          \\(x, _) -> x + y
+"""
+                    |> Review.Test.run (getRule allRule)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder (quickComment allRule) "callingFunction" ]
         , test "called in helper functions, no error" <|
             \() ->
                 """

--- a/tests/AnalyzerTest.elm
+++ b/tests/AnalyzerTest.elm
@@ -907,8 +907,6 @@ findArgumentPatternTest =
                 """
 module A exposing (..)
 
-import Ext
-
 callingFunction { a, b } (c, d) _ (Named "e") (f as g) =
   param
   |> Ext.other
@@ -921,8 +919,6 @@ callingFunction { a, b } (c, d) _ (Named "e") (f as g) =
                 """
 module A exposing (..)
 
-import Ext
-
 callingFunction   ((Named (_, { a, b } as e)), "f")=
   param
   |> Ext.other
@@ -934,8 +930,6 @@ callingFunction   ((Named (_, { a, b } as e)), "f")=
             \() ->
                 """
 module A exposing (..)
-
-import Ext
 
 callingFunction param =
   param
@@ -955,8 +949,6 @@ helperFunction2 { a, b } (c, d) _ (Named "e") (f as g) =
                 """
 module A exposing (..)
 
-import Ext
-
 wrongCallingFunction { a, b } (c, d) _ (Named "e") (f as g) =
   param
   |> Ext.other
@@ -970,8 +962,6 @@ wrongCallingFunction { a, b } (c, d) _ (Named "e") (f as g) =
                 """
 module A exposing (..)
 
-import Ext
-
 callingFunction =
   let
     someInternalFunction { a, b } (c, d) _ (Named "e") (f as g) =
@@ -984,12 +974,28 @@ callingFunction =
                     |> Review.Test.run (getRule allRule)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder (quickComment allRule) "callingFunction" ]
-        , test "missing record" <|
+        , test "used but in a let expressions, error" <|
             \() ->
                 """
 module A exposing (..)
 
-import Ext
+callingFunction =
+  let
+    ({ a, b } as f) = recordAndAs
+    (c, _) = tupleAndIgnored
+    (Named "e") = namedAndString
+  in
+  param
+  |> Ext.other
+  |> internal
+"""
+                    |> Review.Test.run (getRule allRule)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder (quickComment allRule) "callingFunction" ]
+        , test "missing record" <|
+            \() ->
+                """
+module A exposing (..)
 
 callingFunction missing (c, d) _ (Named "e") (f as g) =
   param
@@ -1004,8 +1010,6 @@ callingFunction missing (c, d) _ (Named "e") (f as g) =
                 """
 module A exposing (..)
 
-import Ext
-
 callingFunction { a, b } missing _ (Named "e") (f as g) =
   param
   |> Ext.other
@@ -1018,8 +1022,6 @@ callingFunction { a, b } missing _ (Named "e") (f as g) =
             \() ->
                 """
 module A exposing (..)
-
-import Ext
 
 callingFunction { a, b } (c, d) missing (Named "e") (f as g) =
   param
@@ -1034,8 +1036,6 @@ callingFunction { a, b } (c, d) missing (Named "e") (f as g) =
                 """
 module A exposing (..)
 
-import Ext
-
 callingFunction { a, b } (c, d) _ missing (f as g) =
   param
   |> Ext.other
@@ -1048,8 +1048,6 @@ callingFunction { a, b } (c, d) _ missing (f as g) =
             \() ->
                 """
 module A exposing (..)
-
-import Ext
 
 callingFunction { a, b } (c, d) _ (Named "e") missing =
   param
@@ -1064,8 +1062,6 @@ callingFunction { a, b } (c, d) _ (Named "e") missing =
                 """
 module A exposing (..)
 
-import Ext
-
 callingFunction { a, b } (c, d) _ (Named missing) (f as g) =
   param
   |> Ext.other
@@ -1079,8 +1075,6 @@ callingFunction { a, b } (c, d) _ (Named missing) (f as g) =
                 """
 module A exposing (..)
 
-import Ext
-
 callingFunction { a, b } (c, d) _ (Named "e") (f as g) =
   param
   |> Ext.other
@@ -1092,8 +1086,6 @@ callingFunction { a, b } (c, d) _ (Named "e") (f as g) =
             \() ->
                 """
 module A exposing (..)
-
-import Ext
 
 dallingFunction { a, b } (c, d)  =
   param
@@ -1192,6 +1184,17 @@ callingFunction param =
   case a of
       _ ->
           \\(x, y) -> x + y
+"""
+                    |> Review.Test.run (getRule allRule)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder (quickComment allRule) "callingFunction" ]
+        , test "doesn't match patterns in arguments" <|
+            \() ->
+                """
+module A exposing (..)
+
+callingFunction (a, b) _ { x, y } =
+  a + b + x + y
 """
                     |> Review.Test.run (getRule allRule)
                     |> Review.Test.expectErrors

--- a/tests/ElmSyntaxHelpersTest.elm
+++ b/tests/ElmSyntaxHelpersTest.elm
@@ -72,7 +72,7 @@ traversePatternTests =
                 patterns
                     |> List.concatMap ElmSyntaxHelpers.traversePattern
                     |> Expect.equal patterns
-        , test "patterns with one pattern argument are placed before to their traversed argument" <|
+        , test "patterns with one pattern argument are placed before their traversed argument" <|
             \_ ->
                 let
                     patterns =

--- a/tests/ElmSyntaxHelpersTest.elm
+++ b/tests/ElmSyntaxHelpersTest.elm
@@ -1,6 +1,7 @@
 module ElmSyntaxHelpersTest exposing (..)
 
 import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Pattern exposing (Pattern(..))
 import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation(..))
 import ElmSyntaxHelpers
 import Expect
@@ -47,6 +48,129 @@ hasGenericRecordTests =
                     |> ElmSyntaxHelpers.hasGenericRecord
                     |> Expect.equal True
         ]
+
+
+traversePatternTests : Test
+traversePatternTests =
+    describe "traversePattern"
+        [ test "non recursive patterns are not modified" <|
+            \_ ->
+                let
+                    patterns =
+                        [ AllPattern
+                        , UnitPattern
+                        , CharPattern 'a'
+                        , StringPattern "a"
+                        , IntPattern 0
+                        , HexPattern 0x00
+                        , FloatPattern 3.14
+                        , VarPattern "x"
+                        , RecordPattern [ Node.empty "a", Node.empty "b" ]
+                        ]
+                            |> List.map Node.empty
+                in
+                patterns
+                    |> List.concatMap ElmSyntaxHelpers.traversePattern
+                    |> Expect.equal patterns
+        , test "patterns with one pattern argument are placed before to their traversed argument" <|
+            \_ ->
+                let
+                    patterns =
+                        [ AsPattern (Node.empty UnitPattern) (Node.empty "y")
+                        , ParenthesizedPattern (Node.empty AllPattern)
+                        ]
+                            |> List.map Node.empty
+                in
+                patterns
+                    |> List.concatMap ElmSyntaxHelpers.traversePattern
+                    |> Expect.equal
+                        ([ AsPattern (Node.empty UnitPattern) (Node.empty "y")
+                         , UnitPattern
+                         , ParenthesizedPattern (Node.empty AllPattern)
+                         , AllPattern
+                         ]
+                            |> List.map Node.empty
+                        )
+        , test "patterns with two pattern arguments are placed before their traversed arguments" <|
+            \_ ->
+                let
+                    patterns =
+                        [ UnConsPattern (Node.empty (VarPattern "x")) (Node.empty (VarPattern "xs"))
+                        ]
+                            |> List.map Node.empty
+                in
+                patterns
+                    |> List.concatMap ElmSyntaxHelpers.traversePattern
+                    |> Expect.equal
+                        ([ UnConsPattern (Node.empty (VarPattern "x")) (Node.empty (VarPattern "xs"))
+                         , VarPattern "x"
+                         , VarPattern "xs"
+                         ]
+                            |> List.map Node.empty
+                        )
+        , test "patterns with a list of pattern arguments are placed before their traversed arguments" <|
+            \_ ->
+                let
+                    patterns =
+                        [ TuplePattern [ Node.empty (VarPattern "x"), Node.empty (VarPattern "y") ]
+                        , ListPattern [ Node.empty (CharPattern 'a'), Node.empty (CharPattern 'b') ]
+                        , NamedPattern { moduleName = [], name = "Maybe" } [ Node.empty (IntPattern 0), Node.empty (HexPattern 0x00) ]
+                        ]
+                            |> List.map Node.empty
+                in
+                patterns
+                    |> List.concatMap ElmSyntaxHelpers.traversePattern
+                    |> Expect.equal
+                        ([ TuplePattern [ Node.empty (VarPattern "x"), Node.empty (VarPattern "y") ]
+                         , VarPattern "x"
+                         , VarPattern "y"
+                         , ListPattern [ Node.empty (CharPattern 'a'), Node.empty (CharPattern 'b') ]
+                         , CharPattern 'a'
+                         , CharPattern 'b'
+                         , NamedPattern { moduleName = [], name = "Maybe" } [ Node.empty (IntPattern 0), Node.empty (HexPattern 0x00) ]
+                         , IntPattern 0
+                         , HexPattern 0x00
+                         ]
+                            |> List.map Node.empty
+                        )
+        , test "deeply nested patterns work" <|
+            \_ ->
+                let
+                    pattern =
+                        TuplePattern
+                            [ Node.empty (VarPattern "x")
+                            , ListPattern
+                                [ Node.empty (CharPattern 'a')
+                                , NamedPattern { moduleName = [], name = "Maybe" }
+                                    [ Node.empty (IntPattern 0) ]
+                                    |> Node.empty
+                                ]
+                                |> Node.empty
+                            ]
+                            |> Node.empty
+                in
+                pattern
+                    |> ElmSyntaxHelpers.traversePattern
+                    |> Expect.equal
+                        ([ Node.value pattern
+                         , VarPattern "x"
+                         , ListPattern
+                            [ Node.empty (CharPattern 'a')
+                            , NamedPattern { moduleName = [], name = "Maybe" }
+                                [ Node.empty (IntPattern 0) ]
+                                |> Node.empty
+                            ]
+                         , CharPattern 'a'
+                         , NamedPattern { moduleName = [], name = "Maybe" } [ Node.empty (IntPattern 0) ]
+                         , IntPattern 0
+                         ]
+                            |> List.map Node.empty
+                        )
+        ]
+
+
+
+-- FUZZERS
 
 
 typeAnnotationsFuzzer : Fuzzer (Node TypeAnnotation)

--- a/tests/ElmSyntaxHelpersTest.elm
+++ b/tests/ElmSyntaxHelpersTest.elm
@@ -94,13 +94,11 @@ traversePatternTests =
         , test "patterns with two pattern arguments are placed before their traversed arguments" <|
             \_ ->
                 let
-                    patterns =
-                        [ UnConsPattern (Node.empty (VarPattern "x")) (Node.empty (VarPattern "xs"))
-                        ]
-                            |> List.map Node.empty
+                    pattern =
+                        Node.empty (UnConsPattern (Node.empty (VarPattern "x")) (Node.empty (VarPattern "xs")))
                 in
-                patterns
-                    |> List.concatMap ElmSyntaxHelpers.traversePattern
+                pattern
+                    |> ElmSyntaxHelpers.traversePattern
                     |> Expect.equal
                         ([ UnConsPattern (Node.empty (VarPattern "x")) (Node.empty (VarPattern "xs"))
                          , VarPattern "x"

--- a/tests/Exercise/TicketPleaseTest.elm
+++ b/tests/Exercise/TicketPleaseTest.elm
@@ -1,0 +1,482 @@
+module Exercise.TicketPleaseTest exposing (tests)
+
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Exercise.TicketPlease as TicketPlease
+import Review.Rule exposing (Rule)
+import Review.Test
+import RuleConfig
+import Test exposing (Test, describe, test)
+import TestHelper
+
+
+tests : Test
+tests =
+    describe "TicketPleaseTest"
+        [ exemplar
+        , emptyCommentArguments
+        , numberOfCreatorCommentsArguments
+        , numberOfCreatorCommentsExpressions
+        , assignedToDevTeamArguments
+        , assignedToDevTeamExpressions
+        , assignTicketToArguments
+        , assignTicketIgnoresCases
+        , assignTicketRecordUpdate
+        ]
+
+
+rules : List Rule
+rules =
+    TicketPlease.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
+
+
+exemplar : Test
+exemplar =
+    test "should not report anything for the exemplar" <|
+        \() ->
+            TestHelper.expectNoErrorsForRules rules
+                """
+module TicketPlease exposing (..)
+
+import TicketPleaseSupport exposing (Status(..), Ticket(..), User(..))
+
+emptyComment : ( User, String ) -> Bool
+emptyComment ( _, comment ) =
+    String.isEmpty comment
+
+numberOfCreatorComments : Ticket -> Int
+numberOfCreatorComments (Ticket { createdBy, comments }) =
+    let
+        ( creator, _ ) =
+            createdBy
+    in
+    List.length
+        (List.filter (\\( user, _ ) -> user == creator) comments)
+
+assignedToDevTeam : Ticket -> Bool
+assignedToDevTeam (Ticket { assignedTo }) =
+    case assignedTo of
+        Just (User "Alice") ->
+            True
+
+        Just (User "Bob") ->
+            True
+
+        Just (User "Charlie") ->
+            True
+
+        _ ->
+            False
+
+assignTicketTo : User -> Ticket -> Ticket
+assignTicketTo user (Ticket ({ status } as ticket)) =
+    case status of
+        New ->
+            Ticket { ticket | status = InProgress, assignedTo = Just user }
+
+        Archived ->
+            Ticket ticket
+
+        _ ->
+            Ticket { ticket | assignedTo = Just user }
+"""
+
+
+emptyCommentArguments : Test
+emptyCommentArguments =
+    let
+        comment =
+            Comment "emptyComment argument doesn't destructure a tuple and wild card" "elm.ticket-please.destructure_emptyComment_argument" Essential Dict.empty
+    in
+    describe "emptyComment argument doesn't destructure a tuple and wild card"
+        [ test "doesn't ignore the user" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+emptyComment : ( User, String ) -> Bool
+emptyComment ( user, comment ) =
+    String.isEmpty comment
+
+"""
+                    |> Review.Test.run (TicketPlease.emptyCommentArgumentShouldUseTupleAndIgnore comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "emptyComment"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
+                        ]
+        , test "doesn't destructure the tuple" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+emptyComment : ( User, String ) -> Bool
+emptyComment =
+    Tuple.second >> String.isEmpty
+
+"""
+                    |> Review.Test.run (TicketPlease.emptyCommentArgumentShouldUseTupleAndIgnore comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "emptyComment"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 13 } }
+                        ]
+        ]
+
+
+numberOfCreatorCommentsArguments : Test
+numberOfCreatorCommentsArguments =
+    let
+        comment =
+            Comment "numberOfCreatorComments argument doesn't destructure a record in a named pattern" "elm.ticket-please.destructure_numberOfCreatorComments_argument" Essential Dict.empty
+    in
+    describe "numberOfCreatorComments argument doesn't destructure a record in a named pattern"
+        [ test "doesn't destructure the record" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+numberOfCreatorComments : Ticket -> Int
+numberOfCreatorComments (Ticket ticket) =
+    let
+        ( creator, _ ) =
+            ticket.createdBy
+    in
+    List.length
+        (List.filter (\\( user, _ ) -> user == creator) ticket.comments)
+"""
+                    |> Review.Test.run (TicketPlease.numberOfCreatorCommentsArgumentShouldUseNamedAndRecord comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "numberOfCreatorComments"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 24 } }
+                        ]
+        , test "doesn't destructure the Ticket in the argument" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+numberOfCreatorComments : Ticket -> Int
+numberOfCreatorComments ticket =
+    let
+        (Ticket { createdBy, comments }) =
+            ticket
+
+        ( creator, _ ) =
+            createdBy
+    in
+    List.length
+        (List.filter (\\( user, _ ) -> user == creator) comments)
+"""
+                    |> Review.Test.run (TicketPlease.numberOfCreatorCommentsArgumentShouldUseNamedAndRecord comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "numberOfCreatorComments"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 24 } }
+                        ]
+        ]
+
+
+numberOfCreatorCommentsExpressions : Test
+numberOfCreatorCommentsExpressions =
+    let
+        comment =
+            Comment "numberOfCreatorComments doesn't destructure in let and lambda" "elm.ticket-please.destructure_numberOfCreatorComments_expressions" Essential Dict.empty
+    in
+    describe "numberOfCreatorComments doesn't destructure in let and lambda"
+        [ test "doesn't destructure in the let" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+numberOfCreatorComments : Ticket -> Int
+numberOfCreatorComments (Ticket { createdBy, comments }) =
+    List.length
+        (List.filter (\\( user, _ ) -> user == Tuple.first creator) comments)
+"""
+                    |> Review.Test.run (TicketPlease.numberOfCreatorCommentsDestructuresTupleInLetAndLambda comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "numberOfCreatorComments"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 24 } }
+                        ]
+        , test "doesn't destructure in lambda" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+numberOfCreatorComments : Ticket -> Int
+numberOfCreatorComments (Ticket { createdBy, comments }) =
+    let
+        ( creator, _ ) =
+            createdBy
+    in
+    List.length
+        (List.filter (\\user -> Tuple.first user == creator) comments)
+
+"""
+                    |> Review.Test.run (TicketPlease.numberOfCreatorCommentsDestructuresTupleInLetAndLambda comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "numberOfCreatorComments"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 24 } }
+                        ]
+        ]
+
+
+assignedToDevTeamArguments : Test
+assignedToDevTeamArguments =
+    let
+        comment =
+            Comment "assignedToDevTeam argument doesn't destructure a record in a named pattern" "elm.ticket-please.destructure_assignedToDevTeam_argument" Essential Dict.empty
+    in
+    describe "assignedToDevTeam argument doesn't destructure a record in a named pattern"
+        [ test "doesn't destructure the record" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+assignedToDevTeam : Ticket -> Bool
+assignedToDevTeam (Ticket ticket) =
+    case ticket.assignedTo of
+        Just (User "Alice") ->
+            True
+
+        Just (User "Bob") ->
+            True
+
+        Just (User "Charlie") ->
+            True
+
+        _ ->
+            False
+"""
+                    |> Review.Test.run (TicketPlease.assignedToDevTeamArgumentShouldUseNamedAndRecord comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "assignedToDevTeam"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 18 } }
+                        ]
+        , test "doesn't destructure the Ticket in the argument" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+assignedToDevTeam : Ticket -> Bool
+assignedToDevTeam ticket =
+    let
+        (Ticket { assignedTo }) = ticket
+    in
+    case assignedTo of
+        Just (User "Alice") ->
+            True
+
+        Just (User "Bob") ->
+            True
+
+        Just (User "Charlie") ->
+            True
+
+        _ ->
+            False
+"""
+                    |> Review.Test.run (TicketPlease.assignedToDevTeamArgumentShouldUseNamedAndRecord comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "assignedToDevTeam"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 18 } }
+                        ]
+        ]
+
+
+assignedToDevTeamExpressions : Test
+assignedToDevTeamExpressions =
+    let
+        comment =
+            Comment "assignedToDevTeam argument doesn't destructure in a case block" "elm.ticket-please.destructure_assignedToDevTeam_expressions" Essential Dict.empty
+    in
+    describe "assignedToDevTeam argument doesn't destructure in a case block"
+        [ test "doesn't destructure the string" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+assignedToDevTeam : Ticket -> Bool
+assignedToDevTeam (Ticket { assignedTo }) =
+    case assignedTo of
+        Just (User user) ->
+            user == "Alice || user == "Bob" || user == "Charlie
+
+        _ ->
+            False
+"""
+                    |> Review.Test.run (TicketPlease.assignedToDevTeamArgumentDestructureInCase comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "assignedToDevTeam"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 18 } }
+                        ]
+        , test "doesn't destructure Just or User" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+assignedToDevTeam : Ticket -> Bool
+assignedToDevTeam (Ticket { assignedTo }) =
+    let
+        (User name) = Maybe.withDefault (User "") assignedTo
+    in
+    case name of
+        "Alice" ->
+            True
+
+        "Bob" ->
+            True
+
+        "Charlie" ->
+            True
+
+        _ ->
+            False
+"""
+                    |> Review.Test.run (TicketPlease.assignedToDevTeamArgumentDestructureInCase comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "assignedToDevTeam"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 18 } }
+                        ]
+        ]
+
+
+assignTicketToArguments : Test
+assignTicketToArguments =
+    let
+        comment =
+            Comment "assignTicketTo argument doesn't destructure a record in a named pattern using as" "elm.ticket-please.destructure_assignTicketTo_argument" Essential Dict.empty
+    in
+    describe "assignTicketTo argument doesn't destructure a record in a named pattern using as"
+        [ test "doesn't destructure the record" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+assignTicketTo : User -> Ticket -> Ticket
+assignTicketTo user (Ticket ticket) =
+    case ticket.status of
+        New ->
+            Ticket { ticket | status = InProgress, assignedTo = Just user }
+
+        Archived ->
+            Ticket ticket
+
+        _ ->
+            Ticket { ticket | assignedTo = Just user }
+"""
+                    |> Review.Test.run (TicketPlease.assignTicketToArgumentShouldUseNamedRecordAndAs comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "assignTicketTo"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 15 } }
+                        ]
+        , test "doesn't destructure the Ticket in the argument" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+assignTicketTo : User -> Ticket -> Ticket
+assignTicketTo user ticketParam =
+    let
+        (Ticket ({ status } as ticket)) = ticketParam
+    in
+    case status of
+        New ->
+            Ticket { ticket | status = InProgress, assignedTo = Just user }
+
+        Archived ->
+            Ticket ticket
+
+        _ ->
+            Ticket { ticket | assignedTo = Just user }
+"""
+                    |> Review.Test.run (TicketPlease.assignTicketToArgumentShouldUseNamedRecordAndAs comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "assignTicketTo"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 15 } }
+                        ]
+        , test "doesn't use as in the argument" <|
+            \() ->
+                """
+module TicketPlease exposing (..)
+
+assignTicketTo : User -> Ticket -> Ticket
+assignTicketTo user (Ticket ({ status, createdBy , assignedTo , comments })) =
+    case status of
+        New ->
+            Ticket { status = InProgress, assignedTo = Just user, createdBy = createdBy, comments = comment }
+
+        Archived ->
+            Ticket  { status = status, assignedTo = assignedTo, createdBy = createdBy, comments = comment }
+
+        _ ->
+            Ticket { status = status, assignedTo = Just user, createdBy = createdBy, comments = comment }
+"""
+                    |> Review.Test.run (TicketPlease.assignTicketToArgumentShouldUseNamedRecordAndAs comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "assignTicketTo"
+                            |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 15 } }
+                        ]
+        ]
+
+
+assignTicketIgnoresCases : Test
+assignTicketIgnoresCases =
+    let
+        comment =
+            Comment "assignTicketTo argument doesn't ignore cases" "elm.ticket-please.assignTicketTo_ignore_cases" Actionable Dict.empty
+    in
+    test "assignTicketTo argument doesn't ignore cases" <|
+        \() ->
+            """
+module TicketPlease exposing (..)
+
+assignTicketTo : User -> Ticket -> Ticket
+assignTicketTo user (Ticket ({ status } as ticket)) =
+    case status of
+        New ->
+            Ticket { ticket | status = InProgress, assignedTo = Just user }
+
+        Archived ->
+            Ticket ticket
+
+        Closed ->
+            Ticket { ticket | assignedTo = Just user }
+
+        InProgress ->
+            Ticket { ticket | assignedTo = Just user }
+
+        Resolved ->
+            Ticket { ticket | assignedTo = Just user }
+"""
+                |> Review.Test.run (TicketPlease.assignTicketToArgumentShouldUseIgnore comment)
+                |> Review.Test.expectErrors
+                    [ TestHelper.createExpectedErrorUnder comment "assignTicketTo"
+                        |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 15 } }
+                    ]
+
+
+assignTicketRecordUpdate : Test
+assignTicketRecordUpdate =
+    let
+        comment =
+            Comment "assignTicketTo doesn't use the record update syntax" "elm.ticket-please.assignTicketTo_use_record_update" Actionable Dict.empty
+    in
+    test "assignTicketTo doesn't use the record update syntax" <|
+        \() ->
+            """
+module TicketPlease exposing (..)
+
+assignTicketTo user (Ticket ({ status, createdBy , assignedTo , comments } as ticket)) =
+    case status of
+        New ->
+            Ticket { status = InProgress, assignedTo = Just user, createdBy = createdBy, comments = comment }
+
+        Archived ->
+            Ticket  { status = status, assignedTo = assignedTo, createdBy = createdBy, comments = comment }
+
+        _ ->
+            Ticket { status = status, assignedTo = Just user, createdBy = createdBy, comments = comment }
+"""
+                |> Review.Test.run (TicketPlease.assignTicketUsesRecordUpdate comment)
+                |> Review.Test.expectErrors
+                    [ TestHelper.createExpectedErrorUnder comment "assignTicketTo"
+                        |> Review.Test.atExactly { start = { row = 4, column = 1 }, end = { row = 4, column = 15 } }
+                    ]


### PR DESCRIPTION
Closes #26 
[Sister PR here](https://github.com/exercism/elm-analyzer/pull/69#issue-1979211705).

This one was a complex one, because I had to detect pattern matching in a wide variety of settings (function arguments, case statements, let blocks, lamdba functions). Not all patterns are detected (just what was needed) but adding more would be trivial.

I also did some refactors, mostly renaming functions.