### PR TITLE
Run analyzer on the elm repo in the CI

### DIFF
--- a/.github/workflows/elm_tests.yml
+++ b/.github/workflows/elm_tests.yml
@@ -1,10 +1,13 @@
 name: Elm Test
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [main]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
@@ -72,7 +75,7 @@ jobs:
         run: npx elm-review
 
   check-website-copy-paths:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
@@ -119,7 +122,7 @@ jobs:
           ./bin/check_website-copy_paths.sh website-copy
 
   smoke-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout code
@@ -127,3 +130,18 @@ jobs:
 
       - name: Run Smoke Tests in Docker
         run: bin/run-tests-in-docker.sh
+
+  test-elm-repo-solutions:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout elm-analyzer
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Checkout elm repo
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        with:
+          repository: exercism/elm
+          path: elm_repo
+
+      - name: Run analyzer on all exercises
+        run: bin/analyze-all-exercises-in-docker.sh elm_repo

--- a/.github/workflows/elm_tests.yml
+++ b/.github/workflows/elm_tests.yml
@@ -128,6 +128,21 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+        with:
+          install: true
+
+      - name: Build Docker image and store in cache
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
+        with:
+          context: .
+          push: false
+          load: true
+          tags: elm-analyzer
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Run Smoke Tests in Docker
         run: bin/run-tests-in-docker.sh
 

--- a/.github/workflows/elm_tests.yml
+++ b/.github/workflows/elm_tests.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Run Smoke Tests in Docker
         run: bin/run-tests-in-docker.sh
 
-  test-elm-repo-solutions:
+  analyze-elm-repo-solutions:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout elm-analyzer
@@ -142,6 +142,21 @@ jobs:
         with:
           repository: exercism/elm
           path: elm_repo
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
+        with:
+          install: true
+
+      - name: Build Docker image and store in cache
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09
+        with:
+          context: .
+          push: false
+          load: true
+          tags: exercism/elm-analyzer
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run analyzer on all exercises
         run: bin/analyze-all-exercises-in-docker.sh elm_repo

--- a/.github/workflows/elm_tests.yml
+++ b/.github/workflows/elm_tests.yml
@@ -154,7 +154,7 @@ jobs:
           context: .
           push: false
           load: true
-          tags: exercism/elm-analyzer
+          tags: elm-analyzer
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/bin/analyze-all-exercises-in-docker.sh
+++ b/bin/analyze-all-exercises-in-docker.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -e # Make script exit when a command fail.
+set -u # Exit on usage of undeclared variable.
+# set -x # Trace what gets executed.
+set -o pipefail # Catch failures in pipes.
+
+# Command line argument
+elm_repo_dir=$(realpath $1)
+
+# build docker image
+docker build --rm -t elm-analyzer .
+
+# run image passing the arguments
+docker run \
+    --rm \
+    --read-only \
+    --network none \
+    --mount type=bind,src="$elm_repo_dir",dst=/opt/analyzer/elm_repo \
+    --mount type=tmpfs,dst=/tmp \
+    --volume "${elm_repo_dir}/bin/analyze_all_exercises.sh:/opt/analyzer/bin/analyze_all_exercises.sh" \
+    --entrypoint /opt/analyzer/bin/analyze_all_exercises.sh \
+    elm-analyzer \
+    /opt/analyzer/elm_repo


### PR DESCRIPTION
Closes #65 

This can't work in the CI until https://github.com/exercism/elm/pull/633 is merged, because it uses a script in there.
Edit: the PR is merged, and the script seems to work fine.