### PR TITLE
remove pattern matching rule from `bandwagoner`

### DIFF
--- a/src/Exercise/Bandwagoner.elm
+++ b/src/Exercise/Bandwagoner.elm
@@ -1,11 +1,10 @@
-module Exercise.Bandwagoner exposing (replaceCoachUsesRecordUpdateSyntax, rootForTeamHasExtensibleRecordSignature, rootForTeamUsesPatternMatchingInArgument, ruleConfig)
+module Exercise.Bandwagoner exposing (replaceCoachUsesRecordUpdateSyntax, rootForTeamHasExtensibleRecordSignature, ruleConfig)
 
-import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..), Pattern(..))
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
 import Dict
 import Elm.Syntax.Declaration as Declaration exposing (Declaration)
 import Elm.Syntax.Node as Node exposing (Node(..))
-import Elm.Syntax.Pattern exposing (Pattern(..))
 import ElmSyntaxHelpers
 import Review.Rule as Rule exposing (Error, Rule)
 import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
@@ -20,8 +19,6 @@ ruleConfig =
             (Comment "replaceCoach doesn't use record update syntax" "elm.bandwagoner.use_record_update_syntax" Actionable Dict.empty)
         , CustomRule rootForTeamHasExtensibleRecordSignature
             (Comment "rootForTeam has no extensible record" "elm.bandwagoner.use_extensible_record_signature" Essential Dict.empty)
-        , CustomRule rootForTeamUsesPatternMatchingInArgument
-            (Comment "rootForTeam doesn't use pattern matching in argument" "elm.bandwagoner.use_pattern_matching_in_argument" Essential Dict.empty)
         ]
     }
 
@@ -31,15 +28,6 @@ replaceCoachUsesRecordUpdateSyntax =
     Analyzer.functionCalls
         { calledFrom = TopFunction "replaceCoach"
         , findExpressions = [ RecordUpdate ]
-        , find = Some
-        }
-
-
-rootForTeamUsesPatternMatchingInArgument : Comment -> Rule
-rootForTeamUsesPatternMatchingInArgument =
-    Analyzer.functionCalls
-        { calledFrom = TopFunction "rootForTeam"
-        , findExpressions = [ ArgumentWithPattern Record ]
         , find = Some
         }
 

--- a/tests/Exercise/BandwagonerTest.elm
+++ b/tests/Exercise/BandwagonerTest.elm
@@ -16,7 +16,6 @@ tests =
         [ exemplar
         , noRecordUpdate
         , noExtensibleRecord
-        , noRecordPatternMatching
         ]
 
 
@@ -163,42 +162,3 @@ rootForTeam { stats } =
                             |> Review.Test.atExactly { start = { row = 21, column = 1 }, end = { row = 21, column = 12 } }
                         ]
         ]
-
-
-noRecordPatternMatching : Test
-noRecordPatternMatching =
-    let
-        comment =
-            Comment "rootForTeam doesn't use pattern matching in argument" "elm.bandwagoner.use_pattern_matching_in_argument" Essential Dict.empty
-    in
-    test "rootForTeam doesn't pattern matching in the rootForTeam argument" <|
-        \() ->
-            """
-module Bandwagoner exposing (..)
-
-type alias Coach =
-    { name : String
-    , formerPlayer : Bool
-    }
-
-type alias Stats =
-    { wins : Int
-    , losses : Int
-    }
-
-type alias Team =
-    { name : String
-    , coach : Coach
-    , stats : Stats
-    }
-
-rootForTeam : { a | stats : Stats } -> Bool
-rootForTeam x =
-    x.stats.wins > x.stats.losses
-
-"""
-                |> Review.Test.run (Bandwagoner.rootForTeamUsesPatternMatchingInArgument comment)
-                |> Review.Test.expectErrors
-                    [ TestHelper.createExpectedErrorUnder comment "rootForTeam"
-                        |> Review.Test.atExactly { start = { row = 21, column = 1 }, end = { row = 21, column = 12 } }
-                    ]


### PR DESCRIPTION
Closes #75 
[Sister PR here](https://github.com/exercism/website-copy/pull/2298).

As discussed in the issue, this is too early in the concept tree to require a pattern match/destructure.