### PR TITLE
Add rule for concept exercise `annalyns-infiltration`

### DIFF
--- a/src/Exercise/AnnalynsInfiltration.elm
+++ b/src/Exercise/AnnalynsInfiltration.elm
@@ -1,0 +1,60 @@
+module Exercise.AnnalynsInfiltration exposing (canFastAttackUsesNot, canFreePrisonerUsesBooleanOperators, canSignalPrisonerUsesBooleanOperators, canSpyUsesOr, ruleConfig)
+
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Review.Rule exposing (Rule)
+import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
+
+
+ruleConfig : RuleConfig
+ruleConfig =
+    { slug = Just "annalyns-infiltration"
+    , restrictToFiles = Just [ "src/AnnalynsInfiltration.elm" ]
+    , rules =
+        [ CustomRule canFastAttackUsesNot
+            (Comment "canFastAttack doesn't use not" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty)
+        , CustomRule canSpyUsesOr
+            (Comment "canSpy doesn't use ||" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty)
+        , CustomRule canSignalPrisonerUsesBooleanOperators
+            (Comment "canSignalPrisoner doesn't use boolean operators" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty)
+        , CustomRule canFreePrisonerUsesBooleanOperators
+            (Comment "canFreePrisoner doesn't use boolean operators" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty)
+        ]
+    }
+
+
+canFastAttackUsesNot : Comment -> Rule
+canFastAttackUsesNot =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "canFastAttack"
+        , findExpressions = [ FromExternalModule [ "Basics" ] "not" ]
+        , find = Some
+        }
+
+
+canSpyUsesOr : Comment -> Rule
+canSpyUsesOr =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "canSpy"
+        , findExpressions = [ Operator "||" ]
+        , find = Some
+        }
+
+
+canSignalPrisonerUsesBooleanOperators : Comment -> Rule
+canSignalPrisonerUsesBooleanOperators =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "canSignalPrisoner"
+        , findExpressions = [ Operator "||", Operator "&&" ]
+        , find = Some
+        }
+
+
+canFreePrisonerUsesBooleanOperators : Comment -> Rule
+canFreePrisonerUsesBooleanOperators =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "canFreePrisoner"
+        , findExpressions = [ Operator "||", Operator "&&" ]
+        , find = Some
+        }

--- a/src/Exercise/AnnalynsInfiltration.elm
+++ b/src/Exercise/AnnalynsInfiltration.elm
@@ -9,17 +9,16 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "annalyns-infiltration"
-    , restrictToFiles = Just [ "src/AnnalynsInfiltration.elm" ]
+    { restrictToFiles = Just [ "src/AnnalynsInfiltration.elm" ]
     , rules =
         [ CustomRule canFastAttackUsesNot
-            (Comment "canFastAttack doesn't use not" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty)
+            (Comment "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty)
         , CustomRule canSpyUsesOr
-            (Comment "canSpy doesn't use ||" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty)
+            (Comment "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty)
         , CustomRule canSignalPrisonerUsesBooleanOperators
-            (Comment "canSignalPrisoner doesn't use boolean operators" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty)
+            (Comment "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty)
         , CustomRule canFreePrisonerUsesBooleanOperators
-            (Comment "canFreePrisoner doesn't use boolean operators" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty)
+            (Comment "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty)
         ]
     }
 

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -4,6 +4,7 @@ import Common.NoDebug
 import Common.NoUnused
 import Common.Simplify
 import Common.UseCamelCase
+import Exercise.AnnalynsInfiltration
 import Exercise.Bandwagoner
 import Exercise.BettysBikeShop
 import Exercise.BlorkemonCards
@@ -45,6 +46,7 @@ ruleConfigs =
     , Exercise.TicketPlease.ruleConfig
     , Exercise.TisburyTreasureHunt.ruleConfig
     , Exercise.GottaSnatchEmAll.ruleConfig
+    , Exercise.AnnalynsInfiltration.ruleConfig
 
     -- Practice Exercises
     , Exercise.Strain.ruleConfig

--- a/tests/Exercise/AnnalynsInfiltrationTest.elm
+++ b/tests/Exercise/AnnalynsInfiltrationTest.elm
@@ -1,0 +1,213 @@
+module Exercise.AnnalynsInfiltrationTest exposing (tests)
+
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Exercise.AnnalynsInfiltration as AnnalynsInfiltration
+import Review.Rule exposing (Rule)
+import Review.Test
+import RuleConfig
+import Test exposing (Test, describe, test)
+import TestHelper
+
+
+tests : Test
+tests =
+    describe "AnnalynsInfiltrationTest"
+        [ exemplar
+        , otherSolutions
+        , canFastAttackNoNot
+        , canSpyNoOr
+        , canSignalPrisonerNoBoolOp
+        , canFreePrisonerNoBoolOp
+        ]
+
+
+rules : List Rule
+rules =
+    AnnalynsInfiltration.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
+
+
+exemplar : Test
+exemplar =
+    test "should not report anything for the exemplar" <|
+        \() ->
+            TestHelper.expectNoErrorsForRules rules
+                """
+module AnnalynsInfiltration exposing (canFastAttack, canFreePrisoner, canSignalPrisoner, canSpy, stealthAttackDamage)
+
+canFastAttack : Bool -> Bool
+canFastAttack knightIsAwake =
+    not knightIsAwake
+
+canSpy : Bool -> Bool -> Bool -> Bool
+canSpy knightIsAwake archerIsAwake prisonerIsAwake =
+    knightIsAwake || archerIsAwake || prisonerIsAwake
+
+canSignalPrisoner : Bool -> Bool -> Bool
+canSignalPrisoner archerIsAwake prisonerIsAwake =
+    not archerIsAwake && prisonerIsAwake
+
+canFreePrisoner : Bool -> Bool -> Bool -> Bool -> Bool
+canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent =
+    not knightIsAwake && not archerIsAwake && prisonerIsAwake || not archerIsAwake && petDogIsPresent
+
+stealthAttackDamage : Bool -> Int
+stealthAttackDamage annalynIsDetected =
+    if annalynIsDetected then
+        7
+
+    else
+        12
+"""
+
+
+otherSolutions : Test
+otherSolutions =
+    describe "other solutions that are less obvious but valid" <|
+        [ test "canSignalPrisoner without &&" <|
+            \() ->
+                TestHelper.expectNoErrorsForRules rules
+                    """
+module AnnalynsInfiltration exposing (..)
+
+canFastAttack : Bool -> Bool
+canFastAttack knightIsAwake =
+    not knightIsAwake
+
+canSpy : Bool -> Bool -> Bool -> Bool
+canSpy knightIsAwake archerIsAwake prisonerIsAwake =
+    knightIsAwake || archerIsAwake || prisonerIsAwake
+
+canSignalPrisoner : Bool -> Bool -> Bool
+canSignalPrisoner archerIsAwake prisonerIsAwake =
+    not (archerIsAwake || not prisonerIsAwake)
+
+canFreePrisoner : Bool -> Bool -> Bool -> Bool -> Bool
+canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent =
+    not knightIsAwake && not archerIsAwake && prisonerIsAwake || not archerIsAwake && petDogIsPresent
+"""
+        , test "canFreePrisoner with no ||" <|
+            \() ->
+                TestHelper.expectNoErrorsForRules rules
+                    """
+module AnnalynsInfiltration exposing (..)
+
+canFastAttack : Bool -> Bool
+canFastAttack knightIsAwake =
+    not knightIsAwake
+
+canSpy : Bool -> Bool -> Bool -> Bool
+canSpy knightIsAwake archerIsAwake prisonerIsAwake =
+    knightIsAwake || archerIsAwake || prisonerIsAwake
+
+canSignalPrisoner : Bool -> Bool -> Bool
+canSignalPrisoner archerIsAwake prisonerIsAwake =
+    not archerIsAwake && prisonerIsAwake
+
+canFreePrisoner : Bool -> Bool -> Bool -> Bool -> Bool
+canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent =
+    not
+        (not (not knightIsAwake && not archerIsAwake && prisonerIsAwake)
+            && not (not archerIsAwake && petDogIsPresent)
+        )
+"""
+        ]
+
+
+canFastAttackNoNot : Test
+canFastAttackNoNot =
+    let
+        comment =
+            Comment "canFastAttack doesn't use not" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty
+    in
+    test "canFastAttack doesn't use not" <|
+        \() ->
+            """
+module AnnalynsInfiltration exposing (..)
+
+canFastAttack : Bool -> Bool
+canFastAttack knightIsAwake =
+    if knightIsAwake then False else True
+"""
+                |> Review.Test.run (AnnalynsInfiltration.canFastAttackUsesNot comment)
+                |> Review.Test.expectErrors
+                    [ TestHelper.createExpectedErrorUnder comment "canFastAttack"
+                        |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 14 } }
+                    ]
+
+
+canSpyNoOr : Test
+canSpyNoOr =
+    let
+        comment =
+            Comment "canSpy doesn't use ||" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty
+    in
+    test "canSpy doesn't use ||" <|
+        \() ->
+            """
+module AnnalynsInfiltration exposing (..)
+
+canSpy : Bool -> Bool -> Bool -> Bool
+canSpy knightIsAwake archerIsAwake prisonerIsAwake =
+    if knightIsAwake then True else (if archerIsAwake then True else prisonerIsAwake)
+"""
+                |> Review.Test.run (AnnalynsInfiltration.canSpyUsesOr comment)
+                |> Review.Test.expectErrors
+                    [ TestHelper.createExpectedErrorUnder comment "canSpy"
+                        |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 7 } }
+                    ]
+
+
+canSignalPrisonerNoBoolOp : Test
+canSignalPrisonerNoBoolOp =
+    let
+        comment =
+            Comment "canSignalPrisoner doesn't use boolean operators" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty
+    in
+    test "canSignalPrisoner doesn't use boolean operators" <|
+        \() ->
+            """
+module AnnalynsInfiltration exposing (..)
+
+canSignalPrisoner : Bool -> Bool -> Bool
+canSignalPrisoner archerIsAwake prisonerIsAwake =
+    case (archerIsAwake, prisonerIsAwake) of
+      (False, True) -> True
+      _ -> False
+"""
+                |> Review.Test.run (AnnalynsInfiltration.canSignalPrisonerUsesBooleanOperators comment)
+                |> Review.Test.expectErrors
+                    [ TestHelper.createExpectedErrorUnder comment "canSignalPrisoner"
+                        |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 18 } }
+                    ]
+
+
+canFreePrisonerNoBoolOp : Test
+canFreePrisonerNoBoolOp =
+    let
+        comment =
+            Comment "canFreePrisoner doesn't use boolean operators" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty
+    in
+    test "canFreePrisoner doesn't use boolean operators" <|
+        \() ->
+            """
+module AnnalynsInfiltration exposing (..)
+
+canFreePrisoner : Bool -> Bool -> Bool -> Bool -> Bool
+canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent =
+    case ( ( knightIsAwake, archerIsAwake ), ( prisonerIsAwake, petDogIsPresent ) ) of
+        ( ( _, False ), ( _, True ) ) ->
+            True
+
+        ( ( False, False ), ( True, _ ) ) ->
+            True
+
+        _ ->
+            False
+
+"""
+                |> Review.Test.run (AnnalynsInfiltration.canFreePrisonerUsesBooleanOperators comment)
+                |> Review.Test.expectErrors
+                    [ TestHelper.createExpectedErrorUnder comment "canFreePrisoner"
+                        |> Review.Test.atExactly { start = { row = 5, column = 1 }, end = { row = 5, column = 16 } }
+                    ]

--- a/tests/Exercise/AnnalynsInfiltrationTest.elm
+++ b/tests/Exercise/AnnalynsInfiltrationTest.elm
@@ -118,7 +118,7 @@ canFastAttackNoNot : Test
 canFastAttackNoNot =
     let
         comment =
-            Comment "canFastAttack doesn't use not" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty
+            Comment "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty
     in
     test "canFastAttack doesn't use not" <|
         \() ->
@@ -140,7 +140,7 @@ canSpyNoOr : Test
 canSpyNoOr =
     let
         comment =
-            Comment "canSpy doesn't use ||" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty
+            Comment "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty
     in
     test "canSpy doesn't use ||" <|
         \() ->
@@ -162,7 +162,7 @@ canSignalPrisonerNoBoolOp : Test
 canSignalPrisonerNoBoolOp =
     let
         comment =
-            Comment "canSignalPrisoner doesn't use boolean operators" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty
+            Comment "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty
     in
     test "canSignalPrisoner doesn't use boolean operators" <|
         \() ->
@@ -186,7 +186,7 @@ canFreePrisonerNoBoolOp : Test
 canFreePrisonerNoBoolOp =
     let
         comment =
-            Comment "canFreePrisoner doesn't use boolean operators" "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty
+            Comment "elm.annalyns-infiltration.use_bool_operators" Essential Dict.empty
     in
     test "canFreePrisoner doesn't use boolean operators" <|
         \() ->


### PR DESCRIPTION
Closes #19 
[Sister PR here](https://github.com/exercism/website-copy/pull/2299).

I don't this the rules would catch all strange solutions (like someone one `&&` along with an `if` condition or something), but it should catch obvious attempts.