### PR TITLE
Remove `name` field from `Comment`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,10 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "elm-analyzer",
       "hasInstallScript": true,
       "devDependencies": {
-        "elm-review": "^2.7.6",
-        "elm-tooling": "^1.10.0"
+        "elm-review": "^2.10.3",
+        "elm-tooling": "^1.15.0"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "postinstall": "elm-tooling install"
   },
   "devDependencies": {
-    "elm-review": "^2.7.6",
-    "elm-tooling": "^1.10.0"
+    "elm-review": "^2.10.3",
+    "elm-tooling": "^1.15.0"
   }
 }

--- a/src/Comment.elm
+++ b/src/Comment.elm
@@ -31,8 +31,7 @@ type alias Summary =
 
 
 type alias Comment =
-    { name : String
-    , path : String
+    { path : String
     , commentType : CommentType
     , params : Dict String String
     }
@@ -138,7 +137,7 @@ commentTypeSummaryOrder commentType =
 
 feedbackComment : Comment
 feedbackComment =
-    Comment "please give us feedback" "elm.feedback_request" Informative Dict.empty
+    Comment "elm.feedback_request" Informative Dict.empty
 
 
 
@@ -184,10 +183,9 @@ encodeSummaryComment { path, commentType, params } =
 
 
 encodeComment : Comment -> Value
-encodeComment { name, path, commentType, params } =
+encodeComment { path, commentType, params } =
     Encode.object
-        [ ( "name", Encode.string name )
-        , ( "comment", Encode.string path )
+        [ ( "comment", Encode.string path )
         , ( "type", commentType |> encodeCommentType )
         , ( "params", Encode.dict identity Encode.string params )
         ]
@@ -221,8 +219,7 @@ decodeElmReviewComments elmReviewErrorDecoders =
 
 decodeComment : Decoder Comment
 decodeComment =
-    Decode.map4 Comment
-        (Decode.field "name" Decode.string)
+    Decode.map3 Comment
         (Decode.field "comment" Decode.string)
         (Decode.field "type" decodeCommentType)
         (Decode.field "params" (Decode.dict Decode.string))

--- a/src/Common/NoDebug.elm
+++ b/src/Common/NoDebug.elm
@@ -19,14 +19,14 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    {   restrictToFiles = Nothing
+    { restrictToFiles = Nothing
     , rules =
         [ ImportedRule NoDebug.Log.rule
             noDebugDecoder
-            (Comment "NoDebug.Log" "elm.common.no_debug" Actionable Dict.empty)
+            (Comment "elm.common.no_debug" Actionable Dict.empty)
         , ImportedRule NoDebug.TodoOrToString.rule
             noDebugDecoder
-            (Comment "NoDebug.TodoOrToString" "elm.common.no_debug" Actionable Dict.empty)
+            (Comment "elm.common.no_debug" Actionable Dict.empty)
         ]
     }
 

--- a/src/Common/NoDebug.elm
+++ b/src/Common/NoDebug.elm
@@ -19,8 +19,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Nothing
-    , restrictToFiles = Nothing
+    {   restrictToFiles = Nothing
     , rules =
         [ ImportedRule NoDebug.Log.rule
             noDebugDecoder

--- a/src/Common/NoUnused.elm
+++ b/src/Common/NoUnused.elm
@@ -22,8 +22,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Nothing
-    , restrictToFiles = Nothing
+    { restrictToFiles = Nothing
     , rules =
         -- do not include Modules.rule since exercise modules are always unused
         -- do not include Exports.rule since exported functions are always unused

--- a/src/Common/NoUnused.elm
+++ b/src/Common/NoUnused.elm
@@ -28,26 +28,26 @@ ruleConfig =
         -- do not include Exports.rule since exported functions are always unused
         -- do not include Dependencies.rule since elm.json is standardized
         [ ImportedRule (NoUnused.CustomTypeConstructors.rule [])
-            makeDecoder
-            (Comment "NoUnused.CustomTypeConstructors" "elm.common.no_unused.custom_type_constructors" Actionable Dict.empty)
+            (makeDecoder "NoUnused.CustomTypeConstructors")
+            (Comment "elm.common.no_unused.custom_type_constructors" Actionable Dict.empty)
         , ImportedRule NoUnused.CustomTypeConstructorArgs.rule
-            makeDecoder
-            (Comment "NoUnused.CustomTypeConstructorArgs" "elm.common.no_unused.custom_type_constructor_args" Actionable Dict.empty)
+            (makeDecoder "NoUnused.CustomTypeConstructorArgs")
+            (Comment "elm.common.no_unused.custom_type_constructor_args" Actionable Dict.empty)
         , ImportedRule NoUnused.Variables.rule
-            makeDecoder
-            (Comment "NoUnused.Variables" "elm.common.no_unused.variables" Actionable Dict.empty)
+            (makeDecoder "NoUnused.Variables")
+            (Comment "elm.common.no_unused.variables" Actionable Dict.empty)
         , ImportedRule NoUnused.Parameters.rule
-            makeDecoder
-            (Comment "NoUnused.Parameters" "elm.common.no_unused.parameters" Actionable Dict.empty)
+            (makeDecoder "NoUnused.Parameters")
+            (Comment "elm.common.no_unused.parameters" Actionable Dict.empty)
         , ImportedRule NoUnused.Patterns.rule
-            makeDecoder
-            (Comment "NoUnused.Patterns" "elm.common.no_unused.patterns" Actionable Dict.empty)
+            (makeDecoder "NoUnused.Patterns")
+            (Comment "elm.common.no_unused.patterns" Actionable Dict.empty)
         ]
     }
 
 
-makeDecoder : Comment -> Decoder Comment
-makeDecoder ({ name } as comment) =
+makeDecoder : String -> Comment -> Decoder Comment
+makeDecoder name comment =
     let
         formattedStringsDecoder : Decoder String
         formattedStringsDecoder =

--- a/src/Common/Simplify.elm
+++ b/src/Common/Simplify.elm
@@ -17,8 +17,7 @@ import Simplify
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Nothing
-    , restrictToFiles = Nothing
+    { restrictToFiles = Nothing
     , rules =
         [ ImportedRule (Simplify.rule Simplify.defaults)
             simplifyDecoder

--- a/src/Common/Simplify.elm
+++ b/src/Common/Simplify.elm
@@ -21,7 +21,7 @@ ruleConfig =
     , rules =
         [ ImportedRule (Simplify.rule Simplify.defaults)
             simplifyDecoder
-            (Comment "Simplify" "elm.common.simplify" Actionable Dict.empty)
+            (Comment "elm.common.simplify" Actionable Dict.empty)
         ]
     }
 

--- a/src/Common/UseCamelCase.elm
+++ b/src/Common/UseCamelCase.elm
@@ -17,8 +17,7 @@ import UseCamelCase
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Nothing
-    , restrictToFiles = Nothing
+    { restrictToFiles = Nothing
     , rules =
         [ ImportedRule (UseCamelCase.rule UseCamelCase.default)
             useCameCaseDecoder

--- a/src/Common/UseCamelCase.elm
+++ b/src/Common/UseCamelCase.elm
@@ -21,7 +21,7 @@ ruleConfig =
     , rules =
         [ ImportedRule (UseCamelCase.rule UseCamelCase.default)
             useCameCaseDecoder
-            (Comment "UseCamelCase" "elm.common.camelCase" Actionable Dict.empty)
+            (Comment "elm.common.camelCase" Actionable Dict.empty)
         ]
     }
 

--- a/src/Exercise/Bandwagoner.elm
+++ b/src/Exercise/Bandwagoner.elm
@@ -13,8 +13,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "bandwagoner"
-    , restrictToFiles = Just [ "src/Bandwagoner.elm" ]
+    { restrictToFiles = Just [ "src/Bandwagoner.elm" ]
     , rules =
         [ CustomRule replaceCoachUsesRecordUpdateSyntax
             (Comment "replaceCoach doesn't use record update syntax" "elm.bandwagoner.use_record_update_syntax" Actionable Dict.empty)

--- a/src/Exercise/Bandwagoner.elm
+++ b/src/Exercise/Bandwagoner.elm
@@ -16,11 +16,11 @@ ruleConfig =
     { restrictToFiles = Just [ "src/Bandwagoner.elm" ]
     , rules =
         [ CustomRule replaceCoachUsesRecordUpdateSyntax
-            (Comment "replaceCoach doesn't use record update syntax" "elm.bandwagoner.use_record_update_syntax" Actionable Dict.empty)
+            (Comment "elm.bandwagoner.use_record_update_syntax" Actionable Dict.empty)
         , CustomRule rootForTeamHasExtensibleRecordSignature
-            (Comment "rootForTeam has no extensible record" "elm.bandwagoner.use_extensible_record_signature" Essential Dict.empty)
+            (Comment "elm.bandwagoner.use_extensible_record_signature" Essential Dict.empty)
         , CustomRule rootForTeamUsesPatternMatchingInArgument
-            (Comment "rootForTeam doesn't use pattern matching in argument" "elm.bandwagoner.use_pattern_matching_in_argument" Essential Dict.empty)
+            (Comment "elm.bandwagoner.use_pattern_matching_in_argument" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/BettysBikeShop.elm
+++ b/src/Exercise/BettysBikeShop.elm
@@ -13,8 +13,8 @@ ruleConfig : RuleConfig
 ruleConfig =
     { restrictToFiles = Just [ "src/BettysBikeShop.elm" ]
     , rules =
-        [ CustomRule hasFunctionSignatures (Comment "has no signature" "elm.bettys-bike-shop.use_signature" Essential Dict.empty)
-        , CustomRule importString (Comment "does not import String" "elm.bettys-bike-shop.import_string" Essential Dict.empty)
+        [ CustomRule hasFunctionSignatures (Comment "elm.bettys-bike-shop.use_signature" Essential Dict.empty)
+        , CustomRule importString (Comment "elm.bettys-bike-shop.import_string" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/BettysBikeShop.elm
+++ b/src/Exercise/BettysBikeShop.elm
@@ -11,8 +11,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "bettys-bike-shop"
-    , restrictToFiles = Just [ "src/BettysBikeShop.elm" ]
+    { restrictToFiles = Just [ "src/BettysBikeShop.elm" ]
     , rules =
         [ CustomRule hasFunctionSignatures (Comment "has no signature" "elm.bettys-bike-shop.use_signature" Essential Dict.empty)
         , CustomRule importString (Comment "does not import String" "elm.bettys-bike-shop.import_string" Essential Dict.empty)

--- a/src/Exercise/BlorkemonCards.elm
+++ b/src/Exercise/BlorkemonCards.elm
@@ -9,8 +9,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "blorkemon-cards"
-    , restrictToFiles = Just [ "src/BlorkemonCards.elm" ]
+    { restrictToFiles = Just [ "src/BlorkemonCards.elm" ]
     , rules =
         [ CustomRule maxPowerUsesMax
             (Comment "maxPower doesn't use max" "elm.blorkemon-cards.use_max" Essential Dict.empty)

--- a/src/Exercise/BlorkemonCards.elm
+++ b/src/Exercise/BlorkemonCards.elm
@@ -12,13 +12,13 @@ ruleConfig =
     { restrictToFiles = Just [ "src/BlorkemonCards.elm" ]
     , rules =
         [ CustomRule maxPowerUsesMax
-            (Comment "maxPower doesn't use max" "elm.blorkemon-cards.use_max" Essential Dict.empty)
+            (Comment "elm.blorkemon-cards.use_max" Essential Dict.empty)
         , CustomRule sortByMonsterNameUsesSortBy
-            (Comment "sortByMonsterName doesn't use List.sortBy" "elm.blorkemon-cards.use_sort_by" Essential Dict.empty)
+            (Comment "elm.blorkemon-cards.use_sort_by" Essential Dict.empty)
         , CustomRule expectedWinnerUsesCompareShinyPower
-            (Comment "expectedWinner doesn't use compareShinyPower" "elm.blorkemon-cards.use_shiny_power" Essential Dict.empty)
+            (Comment "elm.blorkemon-cards.use_shiny_power" Essential Dict.empty)
         , CustomRule expectedWinnerUsesCase
-            (Comment "Doesn't use a case expression" "elm.blorkemon-cards.use_case" Essential Dict.empty)
+            (Comment "elm.blorkemon-cards.use_case" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/CustomSet.elm
+++ b/src/Exercise/CustomSet.elm
@@ -9,8 +9,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "custom-set"
-    , restrictToFiles = Just [ "src/CustomSet.elm" ]
+    { restrictToFiles = Just [ "src/CustomSet.elm" ]
     , rules =
         [ CustomRule doNotUseSetModule
             (Comment "Uses the Set module" "elm.custom-set.do_not_use_set" Essential Dict.empty)

--- a/src/Exercise/CustomSet.elm
+++ b/src/Exercise/CustomSet.elm
@@ -12,7 +12,7 @@ ruleConfig =
     { restrictToFiles = Just [ "src/CustomSet.elm" ]
     , rules =
         [ CustomRule doNotUseSetModule
-            (Comment "Uses the Set module" "elm.custom-set.do_not_use_set" Essential Dict.empty)
+            (Comment "elm.custom-set.do_not_use_set" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/GottaSnatchEmAll.elm
+++ b/src/Exercise/GottaSnatchEmAll.elm
@@ -9,8 +9,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "gotta-snatch-em-all"
-    , restrictToFiles = Just [ "src/GottaSnatchEmAll.elm" ]
+    { restrictToFiles = Just [ "src/GottaSnatchEmAll.elm" ]
     , rules =
         [ CustomRule usesSingleton
             (Comment "newCollection doesn't use Set.singleton" "elm.gotta-snatch-em-all.use_singleton" Actionable Dict.empty)

--- a/src/Exercise/GottaSnatchEmAll.elm
+++ b/src/Exercise/GottaSnatchEmAll.elm
@@ -12,21 +12,21 @@ ruleConfig =
     { restrictToFiles = Just [ "src/GottaSnatchEmAll.elm" ]
     , rules =
         [ CustomRule usesSingleton
-            (Comment "newCollection doesn't use Set.singleton" "elm.gotta-snatch-em-all.use_singleton" Actionable Dict.empty)
+            (Comment "elm.gotta-snatch-em-all.use_singleton" Actionable Dict.empty)
         , CustomRule removeDuplicatesUsesSet
-            (Comment "removeDuplicates doesn't use Set functions" "elm.gotta-snatch-em-all.use_set" Essential Dict.empty)
+            (Comment "elm.gotta-snatch-em-all.use_set" Essential Dict.empty)
         , CustomRule extraCardsUsesDiff
-            (Comment "extraCards doesn't use Set.diff" "elm.gotta-snatch-em-all.use_diff" Essential Dict.empty)
+            (Comment "elm.gotta-snatch-em-all.use_diff" Essential Dict.empty)
         , CustomRule boringCardsUsesIntersect
-            (Comment "boringCards doesn't use Set.intersect" "elm.gotta-snatch-em-all.use_intersect" Essential Dict.empty)
+            (Comment "elm.gotta-snatch-em-all.use_intersect" Essential Dict.empty)
         , CustomRule boringCardsUsesFold
-            (Comment "boringCards doesn't use a fold" "elm.gotta-snatch-em-all.boringCards_use_fold" Actionable Dict.empty)
+            (Comment "elm.gotta-snatch-em-all.boringCards_use_fold" Actionable Dict.empty)
         , CustomRule totalCardsUsesUnion
-            (Comment "totalCards doesn't use Set.union" "elm.gotta-snatch-em-all.use_union" Essential Dict.empty)
+            (Comment "elm.gotta-snatch-em-all.use_union" Essential Dict.empty)
         , CustomRule totalCardsUsesFold
-            (Comment "totalCards doesn't use a fold" "elm.gotta-snatch-em-all.totalCards_use_fold" Actionable Dict.empty)
+            (Comment "elm.gotta-snatch-em-all.totalCards_use_fold" Actionable Dict.empty)
         , CustomRule splitShinyCardsUsesPartition
-            (Comment "splitShinyCards doesn't use Set.partition" "elm.gotta-snatch-em-all.use_partition" Essential Dict.empty)
+            (Comment "elm.gotta-snatch-em-all.use_partition" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/ListOps.elm
+++ b/src/Exercise/ListOps.elm
@@ -12,7 +12,7 @@ ruleConfig =
     { restrictToFiles = Just [ "src/ListOps.elm" ]
     , rules =
         [ CustomRule doNotUseListModule
-            (Comment "Uses the List module" "elm.list-ops.do_not_use_list" Essential Dict.empty)
+            (Comment "elm.list-ops.do_not_use_list" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/ListOps.elm
+++ b/src/Exercise/ListOps.elm
@@ -9,8 +9,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "list-ops"
-    , restrictToFiles = Just [ "src/ListOps.elm" ]
+    { restrictToFiles = Just [ "src/ListOps.elm" ]
     , rules =
         [ CustomRule doNotUseListModule
             (Comment "Uses the List module" "elm.list-ops.do_not_use_list" Essential Dict.empty)

--- a/src/Exercise/MariosMarvellousLasagna.elm
+++ b/src/Exercise/MariosMarvellousLasagna.elm
@@ -9,8 +9,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "marios-marvellous-lasagna"
-    , restrictToFiles = Just [ "src/MariosMarvellousLasagna.elm" ]
+    { restrictToFiles = Just [ "src/MariosMarvellousLasagna.elm" ]
     , rules =
         [ CustomRule usesLet
             (Comment "Doesn't use a let expression" "elm.marios-marvellous-lasagna.use_let" Essential Dict.empty)

--- a/src/Exercise/MariosMarvellousLasagna.elm
+++ b/src/Exercise/MariosMarvellousLasagna.elm
@@ -12,7 +12,7 @@ ruleConfig =
     { restrictToFiles = Just [ "src/MariosMarvellousLasagna.elm" ]
     , rules =
         [ CustomRule usesLet
-            (Comment "Doesn't use a let expression" "elm.marios-marvellous-lasagna.use_let" Essential Dict.empty)
+            (Comment "elm.marios-marvellous-lasagna.use_let" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/MazeMaker.elm
+++ b/src/Exercise/MazeMaker.elm
@@ -12,15 +12,15 @@ ruleConfig =
     { restrictToFiles = Just [ "src/MazeMaker.elm" ]
     , rules =
         [ CustomRule roomUsesTreasure
-            (Comment "room doesn't use treasure" "elm.maze-maker.room_use_treasure" Essential Dict.empty)
+            (Comment "elm.maze-maker.room_use_treasure" Essential Dict.empty)
         , CustomRule mazeUsesDeadendRoomAndBranch
-            (Comment "maze doesn't use deadend, room and branch" "elm.maze-maker.maze_use_deadend_room_branch" Essential Dict.empty)
+            (Comment "elm.maze-maker.maze_use_deadend_room_branch" Essential Dict.empty)
         , CustomRule mazeUsesMaze
-            (Comment "maze doesn't use itself recursively" "elm.maze-maker.use_maze_recursively" Essential Dict.empty)
+            (Comment "elm.maze-maker.use_maze_recursively" Essential Dict.empty)
         , CustomRule mazeOfDepthUsesDeadendRoomAndBranch
-            (Comment "mazeOfDepth doesn't use deadend, room and branch" "elm.maze-maker.mazeOfDepth_use_deadend_room_branch" Essential Dict.empty)
+            (Comment "elm.maze-maker.mazeOfDepth_use_deadend_room_branch" Essential Dict.empty)
         , CustomRule mazeOfDepthUsesMazeOfDepth
-            (Comment "mazeOfDepth doesn't use itself recursively" "elm.maze-maker.use_mazeOfDepth_recursively" Essential Dict.empty)
+            (Comment "elm.maze-maker.use_mazeOfDepth_recursively" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/MazeMaker.elm
+++ b/src/Exercise/MazeMaker.elm
@@ -9,8 +9,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "maze-maker"
-    , restrictToFiles = Just [ "src/MazeMaker.elm" ]
+    { restrictToFiles = Just [ "src/MazeMaker.elm" ]
     , rules =
         [ CustomRule roomUsesTreasure
             (Comment "room doesn't use treasure" "elm.maze-maker.room_use_treasure" Essential Dict.empty)

--- a/src/Exercise/Strain.elm
+++ b/src/Exercise/Strain.elm
@@ -12,7 +12,7 @@ ruleConfig =
     { restrictToFiles = Just [ "src/Strain.elm" ]
     , rules =
         [ CustomRule doNotUseFilter
-            (Comment "Uses the List module" "elm.strain.do_not_use_filter" Essential Dict.empty)
+            (Comment "elm.strain.do_not_use_filter" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/Strain.elm
+++ b/src/Exercise/Strain.elm
@@ -9,8 +9,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "strain"
-    , restrictToFiles = Just [ "src/Strain.elm" ]
+    { restrictToFiles = Just [ "src/Strain.elm" ]
     , rules =
         [ CustomRule doNotUseFilter
             (Comment "Uses the List module" "elm.strain.do_not_use_filter" Essential Dict.empty)

--- a/src/Exercise/TicketPlease.elm
+++ b/src/Exercise/TicketPlease.elm
@@ -20,8 +20,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "ticket-please"
-    , restrictToFiles = Just [ "src/TicketPlease.elm" ]
+    { restrictToFiles = Just [ "src/TicketPlease.elm" ]
     , rules =
         [ CustomRule emptyCommentArgumentShouldUseTupleAndIgnore
             (Comment "emptyComment argument doesn't destructure a tuple and wild card" "elm.ticket-please.destructure_emptyComment_argument" Essential Dict.empty)

--- a/src/Exercise/TicketPlease.elm
+++ b/src/Exercise/TicketPlease.elm
@@ -23,21 +23,21 @@ ruleConfig =
     { restrictToFiles = Just [ "src/TicketPlease.elm" ]
     , rules =
         [ CustomRule emptyCommentArgumentShouldUseTupleAndIgnore
-            (Comment "emptyComment argument doesn't destructure a tuple and wild card" "elm.ticket-please.destructure_emptyComment_argument" Essential Dict.empty)
+            (Comment "elm.ticket-please.destructure_emptyComment_argument" Essential Dict.empty)
         , CustomRule numberOfCreatorCommentsArgumentShouldUseNamedAndRecord
-            (Comment "numberOfCreatorComments argument doesn't destructure a record in a named pattern" "elm.ticket-please.destructure_numberOfCreatorComments_argument" Essential Dict.empty)
+            (Comment "elm.ticket-please.destructure_numberOfCreatorComments_argument" Essential Dict.empty)
         , CustomRule numberOfCreatorCommentsDestructuresTupleInLetAndLambda
-            (Comment "numberOfCreatorComments doesn't destructure in let and lambda" "elm.ticket-please.destructure_numberOfCreatorComments_expressions" Essential Dict.empty)
+            (Comment "elm.ticket-please.destructure_numberOfCreatorComments_expressions" Essential Dict.empty)
         , CustomRule assignedToDevTeamArgumentShouldUseNamedAndRecord
-            (Comment "assignedToDevTeam argument doesn't destructure a record in a named pattern" "elm.ticket-please.destructure_assignedToDevTeam_argument" Essential Dict.empty)
+            (Comment "elm.ticket-please.destructure_assignedToDevTeam_argument" Essential Dict.empty)
         , CustomRule assignedToDevTeamArgumentDestructureInCase
-            (Comment "assignedToDevTeam argument doesn't destructure in a case block" "elm.ticket-please.destructure_assignedToDevTeam_expressions" Essential Dict.empty)
+            (Comment "elm.ticket-please.destructure_assignedToDevTeam_expressions" Essential Dict.empty)
         , CustomRule assignTicketToArgumentShouldUseNamedRecordAndAs
-            (Comment "assignTicketTo argument doesn't destructure a record in a named pattern using as" "elm.ticket-please.destructure_assignTicketTo_argument" Essential Dict.empty)
+            (Comment "elm.ticket-please.destructure_assignTicketTo_argument" Essential Dict.empty)
         , CustomRule assignTicketToArgumentShouldUseIgnore
-            (Comment "assignTicketTo argument doesn't ignore cases" "elm.ticket-please.assignTicketTo_ignore_cases" Actionable Dict.empty)
+            (Comment "elm.ticket-please.assignTicketTo_ignore_cases" Actionable Dict.empty)
         , CustomRule assignTicketUsesRecordUpdate
-            (Comment "assignTicketTo doesn't use the record update syntax" "elm.ticket-please.assignTicketTo_use_record_update" Actionable Dict.empty)
+            (Comment "elm.ticket-please.assignTicketTo_use_record_update" Actionable Dict.empty)
         ]
     }
 

--- a/src/Exercise/TisburyTreasureHunt.elm
+++ b/src/Exercise/TisburyTreasureHunt.elm
@@ -10,8 +10,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "tisbury-treasure-hunt"
-    , restrictToFiles = Just [ "src/TisburyTreasureHunt.elm" ]
+    { restrictToFiles = Just [ "src/TisburyTreasureHunt.elm" ]
     , rules =
         [ CustomRule specialCaseSwapPossibleShouldTupleInCase
             (Comment "specialCaseSwapPossible doesn't use a tuple in a case" "elm.tisbury-treasure-hunt.use_tuple_in_case" Essential Dict.empty)

--- a/src/Exercise/TisburyTreasureHunt.elm
+++ b/src/Exercise/TisburyTreasureHunt.elm
@@ -13,11 +13,11 @@ ruleConfig =
     { restrictToFiles = Just [ "src/TisburyTreasureHunt.elm" ]
     , rules =
         [ CustomRule specialCaseSwapPossibleShouldTupleInCase
-            (Comment "specialCaseSwapPossible doesn't use a tuple in a case" "elm.tisbury-treasure-hunt.use_tuple_in_case" Essential Dict.empty)
+            (Comment "elm.tisbury-treasure-hunt.use_tuple_in_case" Essential Dict.empty)
         , CustomRule treasureLocationMatchesPlaceLocationUsesPlaceLocationToTreasureLocation
-            (Comment "treasureLocationMatchesPlaceLocation doesn't use placeLocationToTreasureLocation" "elm.tisbury-treasure-hunt.use_placeLocationToTreasureLocation" Essential Dict.empty)
+            (Comment "elm.tisbury-treasure-hunt.use_placeLocationToTreasureLocation" Essential Dict.empty)
         , CustomRule countPlaceTreasuresUsesTupleSecond
-            (Comment "countPlaceTreasures doesn't use Tuple.second" "elm.tisbury-treasure-hunt.use_tuple_second" Actionable Dict.empty)
+            (Comment "elm.tisbury-treasure-hunt.use_tuple_second" Actionable Dict.empty)
         ]
     }
 

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -9,8 +9,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "top-scorers"
-    , restrictToFiles = Just [ "src/TopScorers.elm" ]
+    { restrictToFiles = Just [ "src/TopScorers.elm" ]
     , rules =
         [ CustomRule removeInsignificantPlayersMustUseFilter
             (Comment "Doesn't use Dict.filter" "elm.top-scorers.use_filter" Essential Dict.empty)

--- a/src/Exercise/TopScorers.elm
+++ b/src/Exercise/TopScorers.elm
@@ -12,19 +12,19 @@ ruleConfig =
     { restrictToFiles = Just [ "src/TopScorers.elm" ]
     , rules =
         [ CustomRule removeInsignificantPlayersMustUseFilter
-            (Comment "Doesn't use Dict.filter" "elm.top-scorers.use_filter" Essential Dict.empty)
+            (Comment "elm.top-scorers.use_filter" Essential Dict.empty)
         , CustomRule resetPlayerGoalCountMustUseInsert
-            (Comment "Doesn't use Dict.insert" "elm.top-scorers.use_insert" Essential Dict.empty)
+            (Comment "elm.top-scorers.use_insert" Essential Dict.empty)
         , CustomRule formatPlayersCannotUseSort
-            (Comment "Uses List.sort" "elm.top-scorers.dont_use_sort" Essential Dict.empty)
+            (Comment "elm.top-scorers.dont_use_sort" Essential Dict.empty)
         , CustomRule combineGamesMustUseMerge
-            (Comment "Doesn't use Dict.merge" "elm.top-scorers.use_merge" Essential Dict.empty)
+            (Comment "elm.top-scorers.use_merge" Essential Dict.empty)
         , CustomRule aggregateScorersMustUseUpdateGoalCountForPlayer
-            (Comment "Doesn't use updateGoalCountForPlayer" "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty)
+            (Comment "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty)
         , CustomRule aggregateScorersMustUseFold
-            (Comment "Doesn't use List.foldl or List.foldr" "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty)
+            (Comment "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty)
         , CustomRule formatPlayerMustUseWithDefault
-            (Comment "Doesn't use Maybe.withDefault" "elm.top-scorers.use_withDefault" Essential Dict.empty)
+            (Comment "elm.top-scorers.use_withDefault" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/TracksOnTracksOnTracks.elm
+++ b/src/Exercise/TracksOnTracksOnTracks.elm
@@ -12,13 +12,13 @@ ruleConfig =
     { restrictToFiles = Just [ "src/TracksOnTracksOnTracks.elm" ]
     , rules =
         [ CustomRule addLanguageUsesCons
-            (Comment "addLanguage doesn't use (::)" "elm.tracks-on-tracks-on-tracks.use_cons" Essential Dict.empty)
+            (Comment "elm.tracks-on-tracks-on-tracks.use_cons" Essential Dict.empty)
         , CustomRule countLanguagesUsesLength
-            (Comment "countLanguages doesn't use List.length" "elm.tracks-on-tracks-on-tracks.use_length" Essential Dict.empty)
+            (Comment "elm.tracks-on-tracks-on-tracks.use_length" Essential Dict.empty)
         , CustomRule reverseListUsesReverse
-            (Comment "reverseList doesn't use List.reverse" "elm.tracks-on-tracks-on-tracks.use_reverse" Essential Dict.empty)
+            (Comment "elm.tracks-on-tracks-on-tracks.use_reverse" Essential Dict.empty)
         , CustomRule excitingListUsesCase
-            (Comment "excitingList doesn't use a case expression" "elm.tracks-on-tracks-on-tracks.use_case" Essential Dict.empty)
+            (Comment "elm.tracks-on-tracks-on-tracks.use_case" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/TracksOnTracksOnTracks.elm
+++ b/src/Exercise/TracksOnTracksOnTracks.elm
@@ -9,8 +9,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "tracks-on-tracks-on-tracks"
-    , restrictToFiles = Just [ "src/TracksOnTracksOnTracks.elm" ]
+    { restrictToFiles = Just [ "src/TracksOnTracksOnTracks.elm" ]
     , rules =
         [ CustomRule addLanguageUsesCons
             (Comment "addLanguage doesn't use (::)" "elm.tracks-on-tracks-on-tracks.use_cons" Essential Dict.empty)

--- a/src/Exercise/TreasureFactory.elm
+++ b/src/Exercise/TreasureFactory.elm
@@ -13,8 +13,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "treasure-factory"
-    , restrictToFiles = Just [ "src/TreasureFactory.elm" ]
+    { restrictToFiles = Just [ "src/TreasureFactory.elm" ]
     , rules =
         [ CustomRule makeChestSignatureMatchesStub
             (Comment "makeChest signature was changed" "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty)

--- a/src/Exercise/TreasureFactory.elm
+++ b/src/Exercise/TreasureFactory.elm
@@ -16,13 +16,13 @@ ruleConfig =
     { restrictToFiles = Just [ "src/TreasureFactory.elm" ]
     , rules =
         [ CustomRule makeChestSignatureMatchesStub
-            (Comment "makeChest signature was changed" "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty)
+            (Comment "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty)
         , CustomRule makeTreasureChestSignatureMatchesStub
-            (Comment "makeTreasureChest signature was changed" "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty)
+            (Comment "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty)
         , CustomRule secureChestSignatureIsCorrect
-            (Comment "secureChest signature is incorrect" "elm.treasure-factory.incorrect_secureChest_signature" Essential Dict.empty)
+            (Comment "elm.treasure-factory.incorrect_secureChest_signature" Essential Dict.empty)
         , CustomRule uniqueTreasuresSignatureIsCorrect
-            (Comment "uniqueTreasures signature is incorrect" "elm.treasure-factory.incorrect_uniqueTreasures_signature" Essential Dict.empty)
+            (Comment "elm.treasure-factory.incorrect_uniqueTreasures_signature" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/TwoFer.elm
+++ b/src/Exercise/TwoFer.elm
@@ -11,8 +11,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "two-fer"
-    , restrictToFiles = Just [ "src/TwoFer.elm" ]
+    { restrictToFiles = Just [ "src/TwoFer.elm" ]
     , rules =
         [ CustomRule hasFunctionSignature (Comment "has no signature" "elm.two-fer.use_signature" Informative Dict.empty)
         , CustomRule usesWithDefault (Comment "Doesn't use withDefault" "elm.two-fer.use_withDefault" Informative Dict.empty)

--- a/src/Exercise/TwoFer.elm
+++ b/src/Exercise/TwoFer.elm
@@ -13,8 +13,8 @@ ruleConfig : RuleConfig
 ruleConfig =
     { restrictToFiles = Just [ "src/TwoFer.elm" ]
     , rules =
-        [ CustomRule hasFunctionSignature (Comment "has no signature" "elm.two-fer.use_signature" Informative Dict.empty)
-        , CustomRule usesWithDefault (Comment "Doesn't use withDefault" "elm.two-fer.use_withDefault" Informative Dict.empty)
+        [ CustomRule hasFunctionSignature (Comment "elm.two-fer.use_signature" Informative Dict.empty)
+        , CustomRule usesWithDefault (Comment "elm.two-fer.use_withDefault" Informative Dict.empty)
         ]
     }
 

--- a/src/Exercise/ValentinesDay.elm
+++ b/src/Exercise/ValentinesDay.elm
@@ -9,8 +9,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "valentines-day"
-    , restrictToFiles = Just [ "src/ValentinesDay.elm" ]
+    { restrictToFiles = Just [ "src/ValentinesDay.elm" ]
     , rules =
         [ CustomRule usesCase
             (Comment "Doesn't use a case expression" "elm.valentines-day.use_case_statement" Essential Dict.empty)

--- a/src/Exercise/ValentinesDay.elm
+++ b/src/Exercise/ValentinesDay.elm
@@ -12,7 +12,7 @@ ruleConfig =
     { restrictToFiles = Just [ "src/ValentinesDay.elm" ]
     , rules =
         [ CustomRule usesCase
-            (Comment "Doesn't use a case expression" "elm.valentines-day.use_case_statement" Essential Dict.empty)
+            (Comment "elm.valentines-day.use_case_statement" Essential Dict.empty)
         ]
     }
 

--- a/src/Exercise/ZebraPuzzle.elm
+++ b/src/Exercise/ZebraPuzzle.elm
@@ -11,8 +11,7 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 
 ruleConfig : RuleConfig
 ruleConfig =
-    { slug = Just "zebra-puzzle"
-    , restrictToFiles = Just [ "src/ZebraPuzzle.elm" ]
+    { restrictToFiles = Just [ "src/ZebraPuzzle.elm" ]
     , rules =
         [ CustomRule hardcodingDrinksWater
             (Comment "Hardcodes solution for drinksWater" "elm.zebra-puzzle.do_not_hardcode_solution" Essential Dict.empty)

--- a/src/Exercise/ZebraPuzzle.elm
+++ b/src/Exercise/ZebraPuzzle.elm
@@ -14,9 +14,9 @@ ruleConfig =
     { restrictToFiles = Just [ "src/ZebraPuzzle.elm" ]
     , rules =
         [ CustomRule hardcodingDrinksWater
-            (Comment "Hardcodes solution for drinksWater" "elm.zebra-puzzle.do_not_hardcode_solution" Essential Dict.empty)
+            (Comment "elm.zebra-puzzle.do_not_hardcode_solution" Essential Dict.empty)
         , CustomRule hardcodingOwnsZebra
-            (Comment "Hardcodes solution for ownsZebra" "elm.zebra-puzzle.do_not_hardcode_solution" Essential Dict.empty)
+            (Comment "elm.zebra-puzzle.do_not_hardcode_solution" Essential Dict.empty)
         ]
     }
 

--- a/src/RuleConfig.elm
+++ b/src/RuleConfig.elm
@@ -6,8 +6,7 @@ import Review.Rule as Rule exposing (Rule)
 
 
 type alias RuleConfig =
-    { slug : Maybe String
-    , restrictToFiles : Maybe (List String)
+    { restrictToFiles : Maybe (List String)
     , rules : List AnalyzerRule
     }
 

--- a/tests/AnalyzerTest.elm
+++ b/tests/AnalyzerTest.elm
@@ -75,7 +75,7 @@ allRules =
 
 quickComment : String -> Comment
 quickComment name =
-    Comment name name Essential Dict.empty
+    Comment name Essential Dict.empty
 
 
 getRule : String -> Rule

--- a/tests/CommentTest.elm
+++ b/tests/CommentTest.elm
@@ -12,6 +12,7 @@ import RuleConfig
 import Test exposing (Test, describe, test)
 
 
+tests : Test
 tests =
     describe "CommentTest tests"
         [ aggregateCommentsTest, encoderDecoderTest, makeSummaryTest, toWebsiteCopyPathTest ]
@@ -19,8 +20,7 @@ tests =
 
 fuzzComment : Fuzzer Comment
 fuzzComment =
-    Fuzz.map4 Comment
-        Fuzz.string
+    Fuzz.map3 Comment
         Fuzz.string
         fuzzCommentType
         (fuzzDict Fuzz.string Fuzz.string)
@@ -49,16 +49,16 @@ encoderDecoderTest =
         [ test "encoding" <|
             \() ->
                 Expect.equal
-                    "{\"name\":\"name\",\"comment\":\"comment\",\"type\":\"celebratory\",\"params\":{\"key\":\"value\"}}"
-                    (Comment "name" "comment" Celebratory (Dict.singleton "key" "value")
+                    "{\"comment\":\"comment\",\"type\":\"celebratory\",\"params\":{\"key\":\"value\"}}"
+                    (Comment "comment" Celebratory (Dict.singleton "key" "value")
                         |> Comment.encodeComment
                         |> Encode.encode 0
                     )
         , test "decoding" <|
             \() ->
                 Expect.equal
-                    (Ok (Comment "name" "comment" Celebratory (Dict.singleton "key" "value")))
-                    ("{\"name\":\"name\",\"comment\":\"comment\",\"type\":\"celebratory\",\"params\":{\"key\":\"value\"}}"
+                    (Ok (Comment "comment" Celebratory (Dict.singleton "key" "value")))
+                    ("{\"comment\":\"comment\",\"type\":\"celebratory\",\"params\":{\"key\":\"value\"}}"
                         |> Decode.decodeString Comment.decodeComment
                     )
         , Test.fuzz fuzzComment "encodeComment then decodeComment should be identity" <|
@@ -75,16 +75,16 @@ aggregateCommentsTest : Test
 aggregateCommentsTest =
     let
         essential =
-            Comment "" "" Essential Dict.empty
+            Comment "" Essential Dict.empty
 
         actionable =
-            Comment "" "" Actionable Dict.empty
+            Comment "" Actionable Dict.empty
 
         informative =
-            Comment "" "" Informative Dict.empty
+            Comment "" Informative Dict.empty
 
         celebratory =
-            Comment "" "" Celebratory Dict.empty
+            Comment "" Celebratory Dict.empty
     in
     describe "aggregateComments should order the comments and create message appropriately"
         [ test "no comments" <|
@@ -196,10 +196,10 @@ toWebsiteCopyPathTest =
     describe "transform Comment into a valid website-copy path"
         [ test "short path" <|
             \() ->
-                Comment.toWebsiteCopyPath (Comment "name" "elm.comment" Informative Dict.empty)
+                Comment.toWebsiteCopyPath (Comment "elm.comment" Informative Dict.empty)
                     |> Expect.equal "analyzer-comments/elm/comment.md"
         , test "long path" <|
             \() ->
-                Comment.toWebsiteCopyPath (Comment "name" "elm.something.or.other.comment" Informative Dict.empty)
+                Comment.toWebsiteCopyPath (Comment "elm.something.or.other.comment" Informative Dict.empty)
                     |> Expect.equal "analyzer-comments/elm/something/or/other/comment.md"
         ]

--- a/tests/Common/NoDebugTest.elm
+++ b/tests/Common/NoDebugTest.elm
@@ -72,7 +72,7 @@ twoFer name =
             \() ->
                 let
                     comment =
-                        Comment "NoDebug.Log" "elm.common.no_debug" Actionable Dict.empty
+                        Comment "elm.common.no_debug" Actionable Dict.empty
                 in
                 Decode.decodeString (Common.NoDebug.noDebugDecoder comment) """
 {
@@ -161,7 +161,7 @@ twoFer name =
             \() ->
                 let
                     comment =
-                        Comment "NoDebug.TodoOrToString" "elm.common.no_debug" Actionable Dict.empty
+                        Comment "elm.common.no_debug" Actionable Dict.empty
                 in
                 Decode.decodeString (Common.NoDebug.noDebugDecoder comment) """
 {
@@ -228,7 +228,7 @@ twoFer name =
             \() ->
                 let
                     comment =
-                        Comment "NoDebug.TodoOrToString" "elm.common.no_debug" Actionable Dict.empty
+                        Comment "elm.common.no_debug" Actionable Dict.empty
                 in
                 Decode.decodeString (Common.NoDebug.noDebugDecoder comment) """
 {

--- a/tests/Common/NoUnusedTest.elm
+++ b/tests/Common/NoUnusedTest.elm
@@ -72,9 +72,9 @@ type TwoFer = TwoFerUnused
             \() ->
                 let
                     comment =
-                        Comment "NoUnused.CustomTypeConstructors" "elm.common.no_unused.custom_type_constructors" Actionable Dict.empty
+                        Comment "elm.common.no_unused.custom_type_constructors" Actionable Dict.empty
                 in
-                Decode.decodeString (NoUnused.makeDecoder comment) """
+                Decode.decodeString (NoUnused.makeDecoder "NoUnused.CustomTypeConstructors" comment) """
 {
 "rule": "NoUnused.CustomTypeConstructors",
 "message": "Type constructor `TwoFerUnused` is not used.",
@@ -102,8 +102,7 @@ type TwoFer = TwoFerUnused
 """
                     |> Expect.equal
                         (Ok
-                            (Comment "NoUnused.CustomTypeConstructors"
-                                "elm.common.no_unused.custom_type_constructors"
+                            (Comment "elm.common.no_unused.custom_type_constructors"
                                 Actionable
                                 (Dict.singleton "definition" " 8| -- unused type constructor TwoFerUnused\n 9| type TwoFer = TwoFerUnused\n                  ^^^^^^^^^^^^")
                             )
@@ -133,9 +132,9 @@ type TwoFer = TwoFerUnused String
             \() ->
                 let
                     comment =
-                        Comment "NoUnused.CustomTypeConstructorArgs" "elm.common.no_unused.custom_type_constructor_args" Actionable Dict.empty
+                        Comment "elm.common.no_unused.custom_type_constructor_args" Actionable Dict.empty
                 in
-                Decode.decodeString (NoUnused.makeDecoder comment) """
+                Decode.decodeString (NoUnused.makeDecoder "NoUnused.CustomTypeConstructorArgs" comment) """
 {
 "rule": "NoUnused.CustomTypeConstructorArgs",
 "message": "Argument is never extracted and therefore never used.",
@@ -163,8 +162,7 @@ type TwoFer = TwoFerUnused String
 """
                     |> Expect.equal
                         (Ok
-                            (Comment "NoUnused.CustomTypeConstructorArgs"
-                                "elm.common.no_unused.custom_type_constructor_args"
+                            (Comment "elm.common.no_unused.custom_type_constructor_args"
                                 Actionable
                                 (Dict.singleton "definition" "11| -- unused type constructor argument String\n12| type Unused = TwoFerUnusedArg String\n                                  ^^^^^^")
                             )
@@ -195,9 +193,9 @@ import Parser.Advanced
             \() ->
                 let
                     comment =
-                        Comment "NoUnused.Variables" "elm.common.no_unused.variables" Actionable Dict.empty
+                        Comment "elm.common.no_unused.variables" Actionable Dict.empty
                 in
-                Decode.decodeString (NoUnused.makeDecoder comment) """
+                Decode.decodeString (NoUnused.makeDecoder "NoUnused.Variables" comment) """
 {
 "rule": "NoUnused.Variables",
 "message": "Imported module `Parser.Advanced` is not used",
@@ -235,8 +233,7 @@ import Parser.Advanced
 """
                     |> Expect.equal
                         (Ok
-                            (Comment "NoUnused.Variables"
-                                "elm.common.no_unused.variables"
+                            (Comment "elm.common.no_unused.variables"
                                 Actionable
                                 (Dict.singleton "definition" "5| -- unused imported module\n6| import Parser.Advanced\n          ^^^^^^^^^^^^^^^")
                             )
@@ -269,9 +266,9 @@ unusedParameter unused =
             \() ->
                 let
                     comment =
-                        Comment "NoUnused.Parameters" "elm.common.no_unused.parameters" Actionable Dict.empty
+                        Comment "elm.common.no_unused.parameters" Actionable Dict.empty
                 in
-                Decode.decodeString (NoUnused.makeDecoder comment) """
+                Decode.decodeString (NoUnused.makeDecoder "NoUnused.Parameters" comment) """
 {
 "rule": "NoUnused.Parameters",
 "message": "Parameter `unused` is not used",
@@ -299,8 +296,7 @@ unusedParameter unused =
 """
                     |> Expect.equal
                         (Ok
-                            (Comment "NoUnused.Parameters"
-                                "elm.common.no_unused.parameters"
+                            (Comment "elm.common.no_unused.parameters"
                                 Actionable
                                 (Dict.singleton "definition" "32| -- unused is unused\n33| unusedParameter unused =\n                    ^^^^^^\n34|   Nothing")
                             )
@@ -334,9 +330,9 @@ f x =
             \() ->
                 let
                     comment =
-                        Comment "NoUnused.Patterns" "elm.common.no_unused.patterns" Actionable Dict.empty
+                        Comment "elm.common.no_unused.patterns" Actionable Dict.empty
                 in
-                Decode.decodeString (NoUnused.makeDecoder comment) """
+                Decode.decodeString (NoUnused.makeDecoder "NoUnused.Patterns" comment) """
 {
 "rule": "NoUnused.Patterns",
 "message": "Value `something` is not used",
@@ -374,8 +370,7 @@ f x =
 """
                     |> Expect.equal
                         (Ok
-                            (Comment "NoUnused.Patterns"
-                                "elm.common.no_unused.patterns"
+                            (Comment "elm.common.no_unused.patterns"
                                 Actionable
                                 (Dict.singleton "definition" "34|  case x of\n35|    Just something -> 1\n             ^^^^^^^^^\n36|    Nothing -> 0")
                             )

--- a/tests/Common/SimplifyTest.elm
+++ b/tests/Common/SimplifyTest.elm
@@ -61,7 +61,7 @@ one =
                         ]
         , test "decoder behavior" <|
             \() ->
-                Decode.decodeString (Common.Simplify.simplifyDecoder (Comment "Simplify" "elm.common.simplify" Actionable Dict.empty)) """
+                Decode.decodeString (Common.Simplify.simplifyDecoder (Comment "elm.common.simplify" Actionable Dict.empty)) """
 {
 "rule": "Simplify",
 "message": "Unnecessary multiplication by 1",
@@ -105,8 +105,7 @@ one =
 """
                     |> Expect.equal
                         (Ok
-                            (Comment "Simplify"
-                                "elm.common.simplify"
+                            (Comment "elm.common.simplify"
                                 Actionable
                                 (Dict.singleton "message" "Simplify: Unnecessary multiplication by 1\n\n42| one =\n43|  1 * 1\n      ^^^^\n\nMultiplying by 1 does not change the value of the number.")
                             )

--- a/tests/Common/UseCamelCaseTest.elm
+++ b/tests/Common/UseCamelCaseTest.elm
@@ -67,7 +67,7 @@ twoFer my_name =
                         ]
         , test "decoder behavior for wrong argument" <|
             \() ->
-                Decode.decodeString (Common.UseCamelCase.useCameCaseDecoder (Comment "UseCamelCase" "elm.common.useCamelCase" Actionable Dict.empty)) """
+                Decode.decodeString (Common.UseCamelCase.useCameCaseDecoder (Comment "elm.common.useCamelCase" Actionable Dict.empty)) """
 {
   "rule": "UseCamelCase",
   "message": "Wrong case style for `my_name` argument.",
@@ -105,8 +105,7 @@ twoFer my_name =
 """
                     |> Expect.equal
                         (Ok
-                            (Comment "UseCamelCase"
-                                "elm.common.useCamelCase"
+                            (Comment "elm.common.useCamelCase"
                                 Actionable
                                 (Dict.fromList [ ( "wrong", "my_name" ), ( "correct", "myName" ) ])
                             )
@@ -136,7 +135,7 @@ two_fer name =
                         ]
         , test "decoder behavior for wrong function name" <|
             \() ->
-                Decode.decodeString (Common.UseCamelCase.useCameCaseDecoder (Comment "UseCamelCase" "elm.common.useCamelCase" Actionable Dict.empty)) """
+                Decode.decodeString (Common.UseCamelCase.useCameCaseDecoder (Comment "elm.common.useCamelCase" Actionable Dict.empty)) """
 {
   "rule": "UseCamelCase",
   "message": "Wrong case style for `two_fer` function.",
@@ -148,8 +147,7 @@ two_fer name =
 """
                     |> Expect.equal
                         (Ok
-                            (Comment "UseCamelCase"
-                                "elm.common.useCamelCase"
+                            (Comment "elm.common.useCamelCase"
                                 Actionable
                                 (Dict.fromList [ ( "wrong", "two_fer" ), ( "correct", "twoFer" ) ])
                             )
@@ -174,7 +172,7 @@ type My_Type = Snake
                         ]
         , test "decoder behavior for wrong type" <|
             \() ->
-                Decode.decodeString (Common.UseCamelCase.useCameCaseDecoder (Comment "UseCamelCase" "elm.common.useCamelCase" Actionable Dict.empty)) """
+                Decode.decodeString (Common.UseCamelCase.useCameCaseDecoder (Comment "elm.common.useCamelCase" Actionable Dict.empty)) """
 {
   "rule": "UseCamelCase",
   "message": "Wrong case style for `My_Type` type.",
@@ -187,8 +185,7 @@ type My_Type = Snake
 """
                     |> Expect.equal
                         (Ok
-                            (Comment "UseCamelCase"
-                                "elm.common.useCamelCase"
+                            (Comment "elm.common.useCamelCase"
                                 Actionable
                                 (Dict.fromList [ ( "wrong", "My_Type" ), ( "correct", "MyType" ) ])
                             )

--- a/tests/Exercise/BandwagonerTest.elm
+++ b/tests/Exercise/BandwagonerTest.elm
@@ -67,7 +67,7 @@ noRecordUpdate : Test
 noRecordUpdate =
     let
         comment =
-            Comment "replaceCoach doesn't use record update syntax" "elm.bandwagoner.use_record_update_syntax" Actionable Dict.empty
+            Comment "elm.bandwagoner.use_record_update_syntax" Actionable Dict.empty
     in
     test "replaceCoach doesn't use record update syntax" <|
         \() ->
@@ -102,7 +102,7 @@ noExtensibleRecord : Test
 noExtensibleRecord =
     let
         comment =
-            Comment "rootForTeam has no extensible record" "elm.bandwagoner.use_extensible_record_signature" Essential Dict.empty
+            Comment "elm.bandwagoner.use_extensible_record_signature" Essential Dict.empty
     in
     describe "rootForTeam doesn't use an extensible record in the signature"
         [ test "no signature" <|
@@ -169,7 +169,7 @@ noRecordPatternMatching : Test
 noRecordPatternMatching =
     let
         comment =
-            Comment "rootForTeam doesn't use pattern matching in argument" "elm.bandwagoner.use_pattern_matching_in_argument" Essential Dict.empty
+            Comment "elm.bandwagoner.use_pattern_matching_in_argument" Essential Dict.empty
     in
     test "rootForTeam doesn't pattern matching in the rootForTeam argument" <|
         \() ->

--- a/tests/Exercise/BettysBikeShopTest.elm
+++ b/tests/Exercise/BettysBikeShopTest.elm
@@ -107,7 +107,7 @@ noFuctionSignature : Test
 noFuctionSignature =
     let
         comment =
-            Comment "has no signature" "elm.bettys-bike-shop.use_signature" Essential Dict.empty
+            Comment "elm.bettys-bike-shop.use_signature" Essential Dict.empty
     in
     describe "solutions without function signatures" <|
         [ test "no function signature on penceToPounds" <|
@@ -202,7 +202,7 @@ noImportString : Test
 noImportString =
     let
         comment =
-            Comment "does not import String" "elm.bettys-bike-shop.import_string" Essential Dict.empty
+            Comment "elm.bettys-bike-shop.import_string" Essential Dict.empty
     in
     describe "solutions that do no import String" <|
         [ test "without the import String" <|

--- a/tests/Exercise/BlorkemonCardsTest.elm
+++ b/tests/Exercise/BlorkemonCardsTest.elm
@@ -153,7 +153,7 @@ noMax : Test
 noMax =
     let
         comment =
-            Comment "maxPower doesn't use max" "elm.blorkemon-cards.use_max" Essential Dict.empty
+            Comment "elm.blorkemon-cards.use_max" Essential Dict.empty
     in
     test "maxPower doesn't use max" <|
         \() ->
@@ -174,7 +174,7 @@ noSortBy : Test
 noSortBy =
     let
         comment =
-            Comment "sortByMonsterName doesn't use List.sortBy" "elm.blorkemon-cards.use_sort_by" Essential Dict.empty
+            Comment "elm.blorkemon-cards.use_sort_by" Essential Dict.empty
     in
     test "sortByMonsterName doesn't use List.sortBy" <|
         \() ->
@@ -202,7 +202,7 @@ noCompareShinyPower : Test
 noCompareShinyPower =
     let
         comment =
-            Comment "expectedWinner doesn't use compareShinyPower" "elm.blorkemon-cards.use_shiny_power" Essential Dict.empty
+            Comment "elm.blorkemon-cards.use_shiny_power" Essential Dict.empty
     in
     test "expectedWinner doesn't use compareShinyPower" <|
         \() ->
@@ -230,7 +230,7 @@ noCase : Test
 noCase =
     let
         comment =
-            Comment "Doesn't use a case expression" "elm.blorkemon-cards.use_case" Essential Dict.empty
+            Comment "elm.blorkemon-cards.use_case" Essential Dict.empty
     in
     test "expectedWinner doesn't use a case expression" <|
         \() ->

--- a/tests/Exercise/CustomSetTest.elm
+++ b/tests/Exercise/CustomSetTest.elm
@@ -235,7 +235,7 @@ usingSet : Test
 usingSet =
     let
         comment =
-            Comment "Uses the Set module" "elm.custom-set.do_not_use_set" Essential Dict.empty
+            Comment "elm.custom-set.do_not_use_set" Essential Dict.empty
     in
     describe "solutions that use the Set function" <|
         [ test "using Set directy" <|

--- a/tests/Exercise/GottaSnatchEmAllTest.elm
+++ b/tests/Exercise/GottaSnatchEmAllTest.elm
@@ -95,7 +95,7 @@ noSingleton : Test
 noSingleton =
     let
         comment =
-            Comment "newCollection doesn't use Set.singleton" "elm.gotta-snatch-em-all.use_singleton" Actionable Dict.empty
+            Comment "elm.gotta-snatch-em-all.use_singleton" Actionable Dict.empty
     in
     test "newCollection doesn't use Set.singleton" <|
         \() ->
@@ -122,7 +122,7 @@ noSetInRemoveDuplicates : Test
 noSetInRemoveDuplicates =
     let
         comment =
-            Comment "removeDuplicates doesn't use Set functions" "elm.gotta-snatch-em-all.use_set" Essential Dict.empty
+            Comment "elm.gotta-snatch-em-all.use_set" Essential Dict.empty
     in
     test "removeDuplicates doesn't use Set functions" <|
         \() ->
@@ -154,7 +154,7 @@ noDiff : Test
 noDiff =
     let
         comment =
-            Comment "extraCards doesn't use Set.diff" "elm.gotta-snatch-em-all.use_diff" Essential Dict.empty
+            Comment "elm.gotta-snatch-em-all.use_diff" Essential Dict.empty
     in
     test "extraCards doesn't use Set.diff" <|
         \() ->
@@ -182,7 +182,7 @@ noIntersect : Test
 noIntersect =
     let
         comment =
-            Comment "boringCards doesn't use Set.intersect" "elm.gotta-snatch-em-all.use_intersect" Essential Dict.empty
+            Comment "elm.gotta-snatch-em-all.use_intersect" Essential Dict.empty
     in
     test "boringCards doesn't use Set.intersect" <|
         \() ->
@@ -219,7 +219,7 @@ boringCardsNoFold : Test
 boringCardsNoFold =
     let
         comment =
-            Comment "boringCards doesn't use a fold" "elm.gotta-snatch-em-all.boringCards_use_fold" Actionable Dict.empty
+            Comment "elm.gotta-snatch-em-all.boringCards_use_fold" Actionable Dict.empty
     in
     test "boringCards doesn't use a fold" <|
         \() ->
@@ -256,7 +256,7 @@ noUnion : Test
 noUnion =
     let
         comment =
-            Comment "totalCards doesn't use Set.union" "elm.gotta-snatch-em-all.use_union" Essential Dict.empty
+            Comment "elm.gotta-snatch-em-all.use_union" Essential Dict.empty
     in
     test "totalCards doesn't use Set.union" <|
         \() ->
@@ -287,7 +287,7 @@ totalCardNoFold : Test
 totalCardNoFold =
     let
         comment =
-            Comment "totalCards doesn't use a fold" "elm.gotta-snatch-em-all.totalCards_use_fold" Actionable Dict.empty
+            Comment "elm.gotta-snatch-em-all.totalCards_use_fold" Actionable Dict.empty
     in
     test "totalCards doesn't use a fold" <|
         \() ->
@@ -318,7 +318,7 @@ noPartition : Test
 noPartition =
     let
         comment =
-            Comment "splitShinyCards doesn't use Set.partition" "elm.gotta-snatch-em-all.use_partition" Essential Dict.empty
+            Comment "elm.gotta-snatch-em-all.use_partition" Essential Dict.empty
     in
     test "splitShinyCards doesn't use Set.partition" <|
         \() ->

--- a/tests/Exercise/ListOpsTest.elm
+++ b/tests/Exercise/ListOpsTest.elm
@@ -99,7 +99,7 @@ usingList : Test
 usingList =
     let
         comment =
-            Comment "Uses the List module" "elm.list-ops.do_not_use_list" Essential Dict.empty
+            Comment "elm.list-ops.do_not_use_list" Essential Dict.empty
     in
     describe "solutions that use the List function" <|
         [ test "using List directy" <|

--- a/tests/Exercise/MariosMarvellousLasagnaTest.elm
+++ b/tests/Exercise/MariosMarvellousLasagnaTest.elm
@@ -86,7 +86,7 @@ noLet : Test
 noLet =
     let
         comment =
-            Comment "Doesn't use a let expression" "elm.marios-marvellous-lasagna.use_let" Essential Dict.empty
+            Comment "elm.marios-marvellous-lasagna.use_let" Essential Dict.empty
     in
     test "doesn't use a let expression" <|
         \() ->

--- a/tests/Exercise/MazeMakerTest.elm
+++ b/tests/Exercise/MazeMakerTest.elm
@@ -87,7 +87,7 @@ roomUsesTreasure : Test
 roomUsesTreasure =
     let
         comment =
-            Comment "room doesn't use treasure" "elm.maze-maker.room_use_treasure" Essential Dict.empty
+            Comment "elm.maze-maker.room_use_treasure" Essential Dict.empty
     in
     test "writing room without treasure" <|
         \() ->
@@ -126,7 +126,7 @@ mazeUsesDeadendRoomAndBranch : Test
 mazeUsesDeadendRoomAndBranch =
     let
         comment =
-            Comment "maze doesn't use deadend, room and branch" "elm.maze-maker.maze_use_deadend_room_branch" Essential Dict.empty
+            Comment "elm.maze-maker.maze_use_deadend_room_branch" Essential Dict.empty
     in
     describe "writing room without deadend, room or branch"
         [ test "without deadend" <|
@@ -290,7 +290,7 @@ mazeUsesMaze : Test
 mazeUsesMaze =
     let
         comment =
-            Comment "maze doesn't use itself recursively" "elm.maze-maker.use_maze_recursively" Essential Dict.empty
+            Comment "elm.maze-maker.use_maze_recursively" Essential Dict.empty
     in
     test "writing maze without recursion" <|
         \() ->
@@ -366,7 +366,7 @@ mazeOfDepthUsesDeadendRoomAndBranch : Test
 mazeOfDepthUsesDeadendRoomAndBranch =
     let
         comment =
-            Comment "mazeOfDepth doesn't use deadend, room and branch" "elm.maze-maker.maze_use_deadend_room_branch" Essential Dict.empty
+            Comment "elm.maze-maker.maze_use_deadend_room_branch" Essential Dict.empty
     in
     describe "writing mazeOfDepth without deadend, room or branch"
         [ test "without deadend" <|
@@ -526,7 +526,7 @@ mazeOfDepthUsesMazeOfDepth : Test
 mazeOfDepthUsesMazeOfDepth =
     let
         comment =
-            Comment "mazeOfDepth doesn't use itself recursively" "elm.maze-maker.use_mazeOfDepth_recursively" Essential Dict.empty
+            Comment "elm.maze-maker.use_mazeOfDepth_recursively" Essential Dict.empty
     in
     test "writing mazeOfDepth without recursion" <|
         \() ->

--- a/tests/Exercise/StrainTest.elm
+++ b/tests/Exercise/StrainTest.elm
@@ -115,7 +115,7 @@ usingFilter : Test
 usingFilter =
     let
         comment =
-            Comment "Uses the List module" "elm.strain.do_not_use_filter" Essential Dict.empty
+            Comment "elm.strain.do_not_use_filter" Essential Dict.empty
     in
     describe "solutions that use filter or filterMap" <|
         [ test "using List.filter" <|

--- a/tests/Exercise/TicketPleaseTest.elm
+++ b/tests/Exercise/TicketPleaseTest.elm
@@ -86,7 +86,7 @@ emptyCommentArguments : Test
 emptyCommentArguments =
     let
         comment =
-            Comment "emptyComment argument doesn't destructure a tuple and wild card" "elm.ticket-please.destructure_emptyComment_argument" Essential Dict.empty
+            Comment "elm.ticket-please.destructure_emptyComment_argument" Essential Dict.empty
     in
     describe "emptyComment argument doesn't destructure a tuple and wild card"
         [ test "doesn't ignore the user" <|
@@ -126,7 +126,7 @@ numberOfCreatorCommentsArguments : Test
 numberOfCreatorCommentsArguments =
     let
         comment =
-            Comment "numberOfCreatorComments argument doesn't destructure a record in a named pattern" "elm.ticket-please.destructure_numberOfCreatorComments_argument" Essential Dict.empty
+            Comment "elm.ticket-please.destructure_numberOfCreatorComments_argument" Essential Dict.empty
     in
     describe "numberOfCreatorComments argument doesn't destructure a record in a named pattern"
         [ test "doesn't destructure the record" <|
@@ -177,7 +177,7 @@ numberOfCreatorCommentsExpressions : Test
 numberOfCreatorCommentsExpressions =
     let
         comment =
-            Comment "numberOfCreatorComments doesn't destructure in let and lambda" "elm.ticket-please.destructure_numberOfCreatorComments_expressions" Essential Dict.empty
+            Comment "elm.ticket-please.destructure_numberOfCreatorComments_expressions" Essential Dict.empty
     in
     describe "numberOfCreatorComments doesn't destructure in let and lambda"
         [ test "doesn't destructure in the let" <|
@@ -222,7 +222,7 @@ assignedToDevTeamArguments : Test
 assignedToDevTeamArguments =
     let
         comment =
-            Comment "assignedToDevTeam argument doesn't destructure a record in a named pattern" "elm.ticket-please.destructure_assignedToDevTeam_argument" Essential Dict.empty
+            Comment "elm.ticket-please.destructure_assignedToDevTeam_argument" Essential Dict.empty
     in
     describe "assignedToDevTeam argument doesn't destructure a record in a named pattern"
         [ test "doesn't destructure the record" <|
@@ -285,7 +285,7 @@ assignedToDevTeamExpressions : Test
 assignedToDevTeamExpressions =
     let
         comment =
-            Comment "assignedToDevTeam argument doesn't destructure in a case block" "elm.ticket-please.destructure_assignedToDevTeam_expressions" Essential Dict.empty
+            Comment "elm.ticket-please.destructure_assignedToDevTeam_expressions" Essential Dict.empty
     in
     describe "assignedToDevTeam argument doesn't destructure in a case block"
         [ test "doesn't destructure the string" <|
@@ -342,7 +342,7 @@ assignTicketToArguments : Test
 assignTicketToArguments =
     let
         comment =
-            Comment "assignTicketTo argument doesn't destructure a record in a named pattern using as" "elm.ticket-please.destructure_assignTicketTo_argument" Essential Dict.empty
+            Comment "elm.ticket-please.destructure_assignTicketTo_argument" Essential Dict.empty
     in
     describe "assignTicketTo argument doesn't destructure a record in a named pattern using as"
         [ test "doesn't destructure the record" <|
@@ -421,7 +421,7 @@ assignTicketIgnoresCases : Test
 assignTicketIgnoresCases =
     let
         comment =
-            Comment "assignTicketTo argument doesn't ignore cases" "elm.ticket-please.assignTicketTo_ignore_cases" Actionable Dict.empty
+            Comment "elm.ticket-please.assignTicketTo_ignore_cases" Actionable Dict.empty
     in
     test "assignTicketTo argument doesn't ignore cases" <|
         \() ->
@@ -457,7 +457,7 @@ assignTicketRecordUpdate : Test
 assignTicketRecordUpdate =
     let
         comment =
-            Comment "assignTicketTo doesn't use the record update syntax" "elm.ticket-please.assignTicketTo_use_record_update" Actionable Dict.empty
+            Comment "elm.ticket-please.assignTicketTo_use_record_update" Actionable Dict.empty
     in
     test "assignTicketTo doesn't use the record update syntax" <|
         \() ->

--- a/tests/Exercise/TisburyTreasureHuntTest.elm
+++ b/tests/Exercise/TisburyTreasureHuntTest.elm
@@ -86,7 +86,7 @@ specialCaseSwapPossibleDoesntUseTupleInCase : Test
 specialCaseSwapPossibleDoesntUseTupleInCase =
     let
         comment =
-            Comment "specialCaseSwapPossible doesn't use a tuple in a case" "elm.tisbury-treasure-hunt.use_tuple_in_case" Essential Dict.empty
+            Comment "elm.tisbury-treasure-hunt.use_tuple_in_case" Essential Dict.empty
     in
     test "specialCaseSwapPossible doesn't use a tuple in a case" <|
         \() ->
@@ -124,7 +124,7 @@ treasureLocationMatchesPlaceLocationDoesntUsePlaceLocationToTreasureLocation : T
 treasureLocationMatchesPlaceLocationDoesntUsePlaceLocationToTreasureLocation =
     let
         comment =
-            Comment "treasureLocationMatchesPlaceLocation doesn't use placeLocationToTreasureLocation" "elm.tisbury-treasure-hunt.use_placeLocationToTreasureLocation" Actionable Dict.empty
+            Comment "elm.tisbury-treasure-hunt.use_placeLocationToTreasureLocation" Actionable Dict.empty
     in
     test "treasureLocationMatchesPlaceLocation doesn't use placeLocationToTreasureLocation" <|
         \() ->
@@ -158,7 +158,7 @@ countPlaceTreasuresDoesntUseTupleSecond : Test
 countPlaceTreasuresDoesntUseTupleSecond =
     let
         comment =
-            Comment "countPlaceTreasures doesn't use Tuple.second" "elm.tisbury-treasure-hunt.use_tuple_second" Actionable Dict.empty
+            Comment "elm.tisbury-treasure-hunt.use_tuple_second" Actionable Dict.empty
     in
     test "countPlaceTreasures doesn't use Tuple.second" <|
         \() ->

--- a/tests/Exercise/TopScorersTest.elm
+++ b/tests/Exercise/TopScorersTest.elm
@@ -172,7 +172,7 @@ ruleTests =
             \() ->
                 let
                     comment =
-                        Comment "Doesn't use Dict.filter" "elm.top-scorers.use_filter" Essential Dict.empty
+                        Comment "elm.top-scorers.use_filter" Essential Dict.empty
                 in
                 """
 module TopScorers exposing (..)
@@ -192,7 +192,7 @@ removeInsignificantPlayers goalThreshold playerGoalCounts =
             \() ->
                 let
                     comment =
-                        Comment "Doesn't use Dict.insert" "elm.top-scorers.use_insert" Essential Dict.empty
+                        Comment "elm.top-scorers.use_insert" Essential Dict.empty
                 in
                 """
 module TopScorers exposing (..)
@@ -211,7 +211,7 @@ resetPlayerGoalCount playerName playerGoalCounts =
             \() ->
                 let
                     comment =
-                        Comment "Uses List.sort" "elm.top-scorers.dont_use_sort" Essential Dict.empty
+                        Comment "elm.top-scorers.dont_use_sort" Essential Dict.empty
                 in
                 """
 module TopScorers exposing (..)
@@ -229,7 +229,7 @@ formatPlayers players =
             \() ->
                 let
                     comment =
-                        Comment "Doesn't use Dict.merge" "elm.top-scorers.use_merge" Essential Dict.empty
+                        Comment "elm.top-scorers.use_merge" Essential Dict.empty
                 in
                 """
 module TopScorers exposing (..)
@@ -249,7 +249,7 @@ combineGames game1 game2 =
             \() ->
                 let
                     comment =
-                        Comment "Doesn't use updateGoalCountForPlayer" "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty
+                        Comment "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty
                 in
                 """
 module TopScorers exposing (..)
@@ -280,7 +280,7 @@ aggregateScorers playerNames =
             \() ->
                 let
                     comment =
-                        Comment "Doesn't use List.foldl or List.foldr" "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty
+                        Comment "elm.top-scorers.use_foldl_and_updateGoalCountForPlayer" Essential Dict.empty
                 in
                 """
 module TopScorers exposing (..)
@@ -303,7 +303,7 @@ aggregateScorers playerNames =
             \() ->
                 let
                     comment =
-                        Comment "Doesn't use Maybe.withDefault" "elm.top-scorers.use_withDefault" Essential Dict.empty
+                        Comment "elm.top-scorers.use_withDefault" Essential Dict.empty
                 in
                 """
 module TopScorers exposing (..)

--- a/tests/Exercise/TracksOnTracksOnTracksTest.elm
+++ b/tests/Exercise/TracksOnTracksOnTracksTest.elm
@@ -118,7 +118,7 @@ noCons : Test
 noCons =
     let
         comment =
-            Comment "addLanguage doesn't use (::)" "elm.tracks-on-tracks-on-tracks.use_cons" Essential Dict.empty
+            Comment "elm.tracks-on-tracks-on-tracks.use_cons" Essential Dict.empty
     in
     test "addLanguage doesn't use (::)" <|
         \() ->
@@ -137,7 +137,7 @@ noLength : Test
 noLength =
     let
         comment =
-            Comment "countLanguages doesn't use List.length" "elm.tracks-on-tracks-on-tracks.use_length" Essential Dict.empty
+            Comment "elm.tracks-on-tracks-on-tracks.use_length" Essential Dict.empty
     in
     test "countLanguages doesn't use List.length" <|
         \() ->
@@ -160,7 +160,7 @@ noReverse : Test
 noReverse =
     let
         comment =
-            Comment "reverseList doesn't use List.reverse" "elm.tracks-on-tracks-on-tracks.use_reverse" Essential Dict.empty
+            Comment "elm.tracks-on-tracks-on-tracks.use_reverse" Essential Dict.empty
     in
     test "reverseList doesn't use List.reverse" <|
         \() ->
@@ -183,7 +183,7 @@ noCase : Test
 noCase =
     let
         comment =
-            Comment "excitingList doesn't use a case expression" "elm.tracks-on-tracks-on-tracks.use_case" Essential Dict.empty
+            Comment "elm.tracks-on-tracks-on-tracks.use_case" Essential Dict.empty
     in
     test "excitingList doesn't use a case expression" <|
         \() ->

--- a/tests/Exercise/TreasureFactoryTest.elm
+++ b/tests/Exercise/TreasureFactoryTest.elm
@@ -97,7 +97,7 @@ incorrectMakeChestSignature : Test
 incorrectMakeChestSignature =
     let
         comment =
-            Comment "makeChest signature was changed" "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty
+            Comment "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty
     in
     describe "solutions with modified makeChest signature" <|
         [ test "no signature" <|
@@ -147,7 +147,7 @@ incorrectMakeTreasureChest : Test
 incorrectMakeTreasureChest =
     let
         comment =
-            Comment "makeTreasureChest signature was changed" "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty
+            Comment "elm.treasure-factory.do_not_change_given_signatures" Essential Dict.empty
     in
     describe "solutions with modified makeTreasureChest signature" <|
         [ test "no signature" <|
@@ -181,7 +181,7 @@ incorrectSecureChest : Test
 incorrectSecureChest =
     let
         comment =
-            Comment "secureChest signature is incorrect" "elm.treasure-factory.incorrect_secureChest_signature" Essential Dict.empty
+            Comment "elm.treasure-factory.incorrect_secureChest_signature" Essential Dict.empty
     in
     describe "solutions with modified secureChest signature" <|
         [ test "no signature" <|
@@ -224,7 +224,7 @@ incorrectUniqueTreasures : Test
 incorrectUniqueTreasures =
     let
         comment =
-            Comment "uniqueTreasures signature is incorrect" "elm.treasure-factory.incorrect_uniqueTreasures_signature" Essential Dict.empty
+            Comment "elm.treasure-factory.incorrect_uniqueTreasures_signature" Essential Dict.empty
     in
     describe "solutions with modified uniqueTreasures signature" <|
         [ test "no signature" <|

--- a/tests/Exercise/TwoFerTest.elm
+++ b/tests/Exercise/TwoFerTest.elm
@@ -78,7 +78,7 @@ noFuctionSignature : Test
 noFuctionSignature =
     let
         comment =
-            Comment "has no signature" "elm.two-fer.use_signature" Informative Dict.empty
+            Comment "elm.two-fer.use_signature" Informative Dict.empty
     in
     describe "solutions without function signatures" <|
         [ test "no function signature" <|
@@ -119,7 +119,7 @@ noWithDefault : Test
 noWithDefault =
     let
         comment =
-            Comment "Doesn't use withDefault" "elm.two-fer.use_withDefault" Informative Dict.empty
+            Comment "elm.two-fer.use_withDefault" Informative Dict.empty
     in
     describe "solutions that don't use withDefault" <|
         [ test "using a case statement" <|

--- a/tests/Exercise/ValentinesDayTest.elm
+++ b/tests/Exercise/ValentinesDayTest.elm
@@ -73,7 +73,7 @@ noCase : Test
 noCase =
     let
         comment =
-            Comment "Doesn't use a case expression" "elm.valentines-day.use_case_statement" Essential Dict.empty
+            Comment "elm.valentines-day.use_case_statement" Essential Dict.empty
     in
     test "doesn't use a case expression" <|
         \() ->

--- a/tests/Exercise/ZebraPuzzleTest.elm
+++ b/tests/Exercise/ZebraPuzzleTest.elm
@@ -358,7 +358,7 @@ hardcodingDrinksWater : Test
 hardcodingDrinksWater =
     let
         comment =
-            Comment "Hardcodes solution for drinksWater" "elm.zebra-puzzle.do_not_hardcode_solution" Essential Dict.empty
+            Comment "elm.zebra-puzzle.do_not_hardcode_solution" Essential Dict.empty
     in
     test "Hardcoding drinksWater" <|
         \() ->
@@ -389,7 +389,7 @@ hardcodingOwnsZebra : Test
 hardcodingOwnsZebra =
     let
         comment =
-            Comment "Hardcodes solution for ownsZebra" "elm.zebra-puzzle.do_not_hardcode_solution" Essential Dict.empty
+            Comment "elm.zebra-puzzle.do_not_hardcode_solution" Essential Dict.empty
     in
     test "Hardcoding ownsZebra" <|
         \() ->


### PR DESCRIPTION
Closes #46 

Full disclosure: this started as an exploration of using `elm-review` with `--extract`, because that's what I wanted to use for the tags analysis.

[Data extraction](https://jfmengels.net/elm-review-insights/) is a new-ish feature of elm-review that allow a rule to export arbitrary JSON data instead of a `Review.Rule.Error`. Since our analysis process is complicated and involves stuffing a JSON string into an error message and decoding it afterwards, I thought I could use data extraction instead to save some time.

It turns out that  `Analyzer.functionCall` was quite simple to port to a data extractor, however there were some issues:
- We are using `Rule.filterErrorsForFiles` to only run rules on specific file names corresponding to their exercise, however it seems that it's not working with data extractors. It's of course possible to do, but would be more verbose because I would need to pass the file name in each call of `Analyzer.functionCall` instead of specifying the file name once per module.
- Not all exercise rules are using `Analyzer.functionCall`, instead they define their own rule, we would need to change them too, and using data extractors requires quite a bit more boilerplate.
- I'm not 100% sure because I didn't get to the testing part, but I think refactoring tests would have involved meaningful changes.
- We would still need to produce normal errors and then decode them again anyway because that's how common rules work, no way around that.

So in the end, I decided that it's not worth doing at this time. I still think it's the right call for the tags though, because they would probably use a different process than `Analyzer.functionCall`.

Sometime during these considerations, I realized that we were not using the slug fields for anything, and so I removed them, and then I thought it was time to remove the unused named field as well. Whenever some tests fail, as long as the test name is meaningful ("that function doesn't do what it's supposed to" kind of name) then there is no confusion at all, even if several rules can lead to the same comment sometimes.