### PR TITLE
Proposal for tagging mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ elm-stuff
 bin/*.js
 src/main.js
 *analysis.json
+*tags.json
 node_modules

--- a/bin/check_files.sh
+++ b/bin/check_files.sh
@@ -37,8 +37,8 @@ function main {
     exit 1
   fi
 
-  jq -S . ${exercise}/expected_analysis.json > /tmp/expected.json
-  jq -S . ${exercise}/analysis.json > /tmp/actual.json
+  jq -S '.comments |= sort' ${exercise}/expected_analysis.json > /tmp/expected.json
+  jq -S '.comments |= sort' ${exercise}/analysis.json > /tmp/actual.json
   if ! diff /tmp/expected.json /tmp/actual.json ;then
     echo "🔥 ${exercise}: expected ${exercise}/analysis.json to equal ${exercise}/expected_analysis.json on successful run 🔥"
     exit 1

--- a/bin/check_files.sh
+++ b/bin/check_files.sh
@@ -44,6 +44,23 @@ function main {
     exit 1
   fi
 
+  if [[ ! -f "${exercise}/expected_tags.json" ]]; then
+    echo "🔥 ${exercise}: expected expected_tags.json to exist 🔥"
+    exit 1
+  fi
+
+  if [[ ! -f "${exercise}/tags.json" ]]; then
+    echo "🔥 ${exercise}: expected tags.json to exist on successful run 🔥"
+    exit 1
+  fi
+
+  jq -S 'sort' ${exercise}/expected_tags.json > /tmp/expected.json
+  jq -S 'sort' ${exercise}/tags.json > /tmp/actual.json
+  if ! diff /tmp/expected.json /tmp/actual.json ;then
+    echo "🔥 ${exercise}: expected ${exercise}/tags.json to equal ${exercise}/expected_tags.json on successful run 🔥"
+    exit 1
+  fi
+
   echo "🏁 ${exercise}: expected files present and correct after successful run 🏁"
 }
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -35,7 +35,7 @@ npx elm-review $INPUT_DIR \
 cat /tmp/elm-review-report.json | node ./bin/cli.js > $OUTPUT_DIR/analysis.json
 
 # Get tags
-jq '.extracts .Tags' /tmp/elm-review-report.json > $OUTPUT_DIR/tags.json
+jq '.extracts | to_entries | map(.value) | add' /tmp/elm-review-report.json > $OUTPUT_DIR/tags.json
 
 set -e
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -35,7 +35,7 @@ npx elm-review $INPUT_DIR \
 cat /tmp/elm-review-report.json | node ./bin/cli.js > $OUTPUT_DIR/analysis.json
 
 # Get tags
-jq '.extracts | to_entries | map(.value) | add' /tmp/elm-review-report.json > $OUTPUT_DIR/tags.json
+jq '.extracts | to_entries | map(.value) | add | sort' /tmp/elm-review-report.json > $OUTPUT_DIR/tags.json
 
 set -e
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -20,14 +20,23 @@ if [ -f solution_cache.tar ]; then
     INPUT_DIR=/tmp/sol
 fi
 
-# Run analysis
 # Temporarily disable -e mode
 set +e
+
+# Run analysis
 npx elm-review $INPUT_DIR \
         --elmjson $INPUT_DIR/elm.json \
         --config . \
         --report=json \
-  | node ./bin/cli.js > $OUTPUT_DIR/analysis.json
+        --extract \
+  > /tmp/elm-review-report.json
+
+# Get comments
+cat /tmp/elm-review-report.json | node ./bin/cli.js > $OUTPUT_DIR/analysis.json
+
+# Get tags
+jq '.extracts .Tags' /tmp/elm-review-report.json > $OUTPUT_DIR/tags.json
+
 set -e
 
 echo Finished

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -10,6 +10,7 @@ set -o pipefail # Catch failures in pipes.
 # Remove trailing slash for elm-review
 INPUT_DIR=${2%/}
 OUTPUT_DIR=${3%/}
+OUTPUT_TAGS=${4:-false}
 
 # Check if script running in docker
 if [ -f solution_cache.tar ]; then
@@ -30,13 +31,14 @@ npx elm-review $INPUT_DIR \
         --report=json \
         --extract \
   > /tmp/elm-review-report.json
+set -e
 
-# Get comments
+# Output comments
 cat /tmp/elm-review-report.json | node ./bin/cli.js > $OUTPUT_DIR/analysis.json
 
-# Get tags
-jq '.extracts | to_entries | map(.value) | add | sort' /tmp/elm-review-report.json > $OUTPUT_DIR/tags.json
-
-set -e
+if [ $OUTPUT_TAGS = "--tags" ]; then
+  # Output tags
+  jq '.extracts | to_entries | map(.value) | add | sort' /tmp/elm-review-report.json > $OUTPUT_DIR/tags.json
+fi
 
 echo Finished

--- a/bin/smoke_test.sh
+++ b/bin/smoke_test.sh
@@ -8,7 +8,7 @@ set -o pipefail # Catch failures in pipes.
 for solution in test_data/*/* ; do
   slug=$(basename $(dirname $solution))
   # run analysis
-  bin/run.sh $slug $solution $solution > /dev/null
+  bin/run.sh $slug $solution $solution --tags > /dev/null
   # check result
   bin/check_files.sh $solution
 done

--- a/bin/smoke_test.sh
+++ b/bin/smoke_test.sh
@@ -8,7 +8,7 @@ set -o pipefail # Catch failures in pipes.
 for solution in test_data/*/* ; do
   slug=$(basename $(dirname $solution))
   # run analysis
-  bin/run.sh $slug $solution $solution
+  bin/run.sh $slug $solution $solution > /dev/null
   # check result
   bin/check_files.sh $solution
 done

--- a/src/ElmSyntaxHelpers.elm
+++ b/src/ElmSyntaxHelpers.elm
@@ -1,4 +1,4 @@
-module ElmSyntaxHelpers exposing (hasGenericRecord, traversePattern, typeAnnotationsMatch)
+module ElmSyntaxHelpers exposing (hasDestructuringPattern, hasGenericRecord, traversePattern, typeAnnotationsMatch)
 
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Pattern exposing (Pattern(..))
@@ -74,6 +74,31 @@ hasGenericRecord annotation =
 
         Unit ->
             False
+
+
+hasDestructuringPattern : Node Pattern -> Bool
+hasDestructuringPattern fullPattern =
+    let
+        destructuringPattern pattern =
+            case Node.value pattern of
+                RecordPattern _ ->
+                    True
+
+                UnConsPattern _ _ ->
+                    True
+
+                TuplePattern _ ->
+                    True
+
+                NamedPattern _ _ ->
+                    True
+
+                _ ->
+                    False
+    in
+    fullPattern
+        |> traversePattern
+        |> List.any destructuringPattern
 
 
 traversePattern : Node Pattern -> List (Node Pattern)

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -23,12 +23,16 @@ import Exercise.ValentinesDay
 import Exercise.ZebraPuzzle
 import Review.Rule as Rule exposing (Rule)
 import RuleConfig exposing (RuleConfig)
+import Tags
 
 
 ruleConfigs : List RuleConfig
 ruleConfigs =
-    [ -- Common Rules
-      Common.NoUnused.ruleConfig
+    [ -- Tags
+      Tags.ruleConfig
+
+    -- Common Rules
+    , Common.NoUnused.ruleConfig
     , Common.Simplify.ruleConfig
     , Common.NoDebug.ruleConfig
     , Common.UseCamelCase.ruleConfig

--- a/src/RuleConfig.elm
+++ b/src/RuleConfig.elm
@@ -14,6 +14,7 @@ type alias RuleConfig =
 type AnalyzerRule
     = CustomRule (Comment -> Rule) Comment
     | ImportedRule Rule (Comment -> Decoder Comment) Comment
+    | TagRule Rule
 
 
 analyzerRuleToRule : AnalyzerRule -> Rule
@@ -23,6 +24,9 @@ analyzerRuleToRule analyzerRule =
             toRule comment
 
         ImportedRule rule _ _ ->
+            rule
+
+        TagRule rule ->
             rule
 
 
@@ -35,15 +39,21 @@ analyzerRuleToDecoder analyzerRule =
         ImportedRule _ toDecoder comment ->
             Just (toDecoder comment)
 
+        TagRule _ ->
+            Nothing
 
-analyzerRuleToComment : AnalyzerRule -> Comment
+
+analyzerRuleToComment : AnalyzerRule -> Maybe Comment
 analyzerRuleToComment analyzerRule =
     case analyzerRule of
         CustomRule _ comment ->
-            comment
+            Just comment
 
         ImportedRule _ _ comment ->
-            comment
+            Just comment
+
+        TagRule _ ->
+            Nothing
 
 
 getRules : RuleConfig -> List Rule
@@ -63,7 +73,7 @@ getDecoders =
 
 getComments : List RuleConfig -> List Comment
 getComments =
-    List.concatMap (.rules >> List.map analyzerRuleToComment)
+    List.concatMap (.rules >> List.filterMap analyzerRuleToComment)
 
 
 makeConfig : List RuleConfig -> List Rule

--- a/src/Tags.elm
+++ b/src/Tags.elm
@@ -37,7 +37,7 @@ ruleConfig =
 
 commonTagsRule : Rule
 commonTagsRule =
-    Rule.newProjectRuleSchema "Tags" commonTagsProjectContext
+    Rule.newProjectRuleSchema "commonTags" commonTagsProjectContext
         |> Rule.withModuleVisitor (Rule.withSimpleModuleDefinitionVisitor (always []))
         |> Rule.withModuleContextUsingContextCreator
             { fromModuleToProject = fromModuleToProject
@@ -87,7 +87,7 @@ dataExtractor =
 
 expressionTagsRule : Rule
 expressionTagsRule =
-    Rule.newProjectRuleSchema "Tags" emptyProjectContext
+    Rule.newProjectRuleSchema "expressionTags" emptyProjectContext
         |> Rule.withModuleVisitor (Rule.withExpressionEnterVisitor expressionVisitor)
         |> Rule.withModuleContextUsingContextCreator
             { fromModuleToProject = fromModuleToProject

--- a/src/Tags.elm
+++ b/src/Tags.elm
@@ -2,7 +2,6 @@ module Tags exposing (commonTagsRule, expressionTagsRule, ruleConfig)
 
 import Elm.Syntax.Expression exposing (Expression(..), LetDeclaration(..))
 import Elm.Syntax.Node as Node exposing (Node(..))
-import Elm.Syntax.Pattern exposing (Pattern(..))
 import ElmSyntaxHelpers
 import Json.Encode as Encode exposing (Value)
 import Review.ModuleNameLookupTable as LookupTable exposing (ModuleNameLookupTable)

--- a/src/Tags.elm
+++ b/src/Tags.elm
@@ -1,0 +1,218 @@
+module Tags exposing (commonTagsRule, expressionTagsRule, ruleConfig)
+
+import Elm.Syntax.Expression exposing (Expression(..), LetDeclaration(..))
+import Elm.Syntax.Node as Node exposing (Node(..))
+import Elm.Syntax.Pattern exposing (Pattern(..))
+import ElmSyntaxHelpers
+import Json.Encode as Encode exposing (Value)
+import Review.ModuleNameLookupTable as LookupTable exposing (ModuleNameLookupTable)
+import Review.Rule as Rule exposing (Rule)
+import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
+import Set exposing (Set)
+
+
+type alias Tag =
+    String
+
+
+type alias ProjectContext =
+    Set Tag
+
+
+type alias ModuleContext =
+    { lookupTable : ModuleNameLookupTable
+    , tags : Set Tag
+    }
+
+
+ruleConfig : RuleConfig
+ruleConfig =
+    { restrictToFiles = Nothing
+    , rules =
+        [ TagRule commonTagsRule
+        , TagRule expressionTagsRule
+        ]
+    }
+
+
+commonTagsRule : Rule
+commonTagsRule =
+    Rule.newProjectRuleSchema "Tags" commonTags
+        |> Rule.withModuleVisitor (Rule.withSimpleModuleDefinitionVisitor (always []))
+        |> Rule.withModuleContextUsingContextCreator
+            { fromModuleToProject = fromModuleToProject
+            , fromProjectToModule = fromProjectToModule
+            , foldProjectContexts = Set.union
+            }
+        |> Rule.withDataExtractor dataExtractor
+        |> Rule.fromProjectRuleSchema
+
+
+commonTags : Set Tag
+commonTags =
+    Set.fromList
+        [ "paradigm:functional"
+        , "technique:immutability"
+        , "uses:module"
+        ]
+
+
+fromProjectToModule : Rule.ContextCreator ProjectContext ModuleContext
+fromProjectToModule =
+    Rule.initContextCreator
+        (\lookupTable _ ->
+            { lookupTable = lookupTable
+            , tags = Set.empty
+            }
+        )
+        |> Rule.withModuleNameLookupTable
+
+
+fromModuleToProject : Rule.ContextCreator ModuleContext ProjectContext
+fromModuleToProject =
+    Rule.initContextCreator (\{ tags } -> tags)
+
+
+dataExtractor : ProjectContext -> Value
+dataExtractor =
+    Set.toList >> Encode.list Encode.string
+
+
+expressionTagsRule : Rule
+expressionTagsRule =
+    Rule.newProjectRuleSchema "Tags" Set.empty
+        |> Rule.withModuleVisitor (Rule.withExpressionEnterVisitor expressionVisitor)
+        |> Rule.withModuleContextUsingContextCreator
+            { fromModuleToProject = fromModuleToProject
+            , fromProjectToModule = fromProjectToModule
+            , foldProjectContexts = Set.union
+            }
+        |> Rule.withDataExtractor dataExtractor
+        |> Rule.fromProjectRuleSchema
+
+
+expressionVisitor : Node Expression -> ModuleContext -> ( List never, ModuleContext )
+expressionVisitor ((Node range expression) as node) ({ lookupTable, tags } as context) =
+    case expression of
+        FunctionOrValue _ name ->
+            case LookupTable.moduleNameFor lookupTable node of
+                Nothing ->
+                    ( [], { context | tags = Set.union tags (matchExpression node) } )
+
+                Just originalModuleName ->
+                    ( [], { context | tags = Set.union tags (matchExpression (Node range (FunctionOrValue originalModuleName name))) } )
+
+        _ ->
+            ( [], { context | tags = Set.union tags (matchExpression node) } )
+
+
+matchExpression : Node Expression -> Set Tag
+matchExpression (Node range expression) =
+    case expression of
+        FunctionOrValue [ "Set" ] _ ->
+            Set.fromList [ "construct:set", "technique:immutable-collection", "technique:sorted-collection" ]
+
+        FunctionOrValue [ "Dict" ] _ ->
+            Set.fromList [ "construct:dictionary", "technique:immutable-collection", "technique:sorted-collection" ]
+
+        FunctionOrValue [ "Random" ] _ ->
+            Set.singleton "technique:randomness"
+
+        FunctionOrValue [ "Regex" ] _ ->
+            Set.singleton "technique:regular-expression"
+
+        FunctionOrValue [ "Debug" ] _ ->
+            Set.singleton "uses:debug"
+
+        PrefixOperator "+" ->
+            Set.singleton "construct:add"
+
+        OperatorApplication "+" _ _ _ ->
+            Set.singleton "construct:add"
+
+        PrefixOperator "-" ->
+            Set.singleton "construct:subtract"
+
+        OperatorApplication "-" _ _ _ ->
+            Set.singleton "construct:subtract"
+
+        PrefixOperator "*" ->
+            Set.singleton "construct:multiply"
+
+        OperatorApplication "*" _ _ _ ->
+            Set.singleton "construct:multiply"
+
+        PrefixOperator "/" ->
+            Set.singleton "construct:divide"
+
+        OperatorApplication "/" _ _ _ ->
+            Set.singleton "construct:divide"
+
+        PrefixOperator "//" ->
+            Set.singleton "construct:divide"
+
+        OperatorApplication "//" _ _ _ ->
+            Set.singleton "construct:divide"
+
+        PrefixOperator "==" ->
+            Set.fromList [ "construct:equality", "technique:equality-comparison", "construct:boolean" ]
+
+        OperatorApplication "==" _ _ _ ->
+            Set.fromList [ "construct:equality", "technique:equality-comparison", "construct:boolean" ]
+
+        PrefixOperator "/=" ->
+            Set.fromList [ "construct:inequality", "technique:equality-comparison", "construct:boolean" ]
+
+        OperatorApplication "/=" _ _ _ ->
+            Set.fromList [ "construct:inequality", "technique:equality-comparison", "construct:boolean" ]
+
+        UnitExpr ->
+            Set.singleton "uses:unit"
+
+        Floatable _ ->
+            Set.fromList [ "construct:float", "construct:floating-point-number" ]
+
+        Integer _ ->
+            Set.fromList [ "construct:integral-number", "construct:int" ]
+
+        Hex _ ->
+            Set.fromList [ "construct:hexadecimal-number", "construct:integral-number", "construct:int" ]
+
+        Negation _ ->
+            Set.singleton "construct:unary-minus"
+
+        Literal _ ->
+            if range.end.row > range.start.row then
+                Set.fromList [ "construct:string", "construct:multiline-string" ]
+
+            else
+                Set.singleton "construct:string"
+
+        LambdaExpression _ ->
+            Set.singleton "construct:lambda"
+
+        IfBlock _ _ _ ->
+            Set.fromList [ "construct:if", "construct:boolean" ]
+
+        LetExpression { declarations } ->
+            if List.any (Node.value >> usesProperDestructuring) declarations then
+                Set.fromList [ "uses:destructure", "construct:pattern-matching" ]
+
+            else
+                Set.empty
+
+        _ ->
+            Set.empty
+
+
+usesProperDestructuring : LetDeclaration -> Bool
+usesProperDestructuring letDeclaration =
+    case letDeclaration of
+        LetDestructuring _ _ ->
+            True
+
+        LetFunction { declaration } ->
+            declaration
+                |> Node.value
+                |> .arguments
+                |> List.any ElmSyntaxHelpers.hasDestructuringPattern

--- a/src/Tags.elm
+++ b/src/Tags.elm
@@ -5,7 +5,6 @@ import Elm.Syntax.Expression exposing (Expression(..), FunctionImplementation, L
 import Elm.Syntax.Module exposing (Module)
 import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Type exposing (Type)
-import Elm.Syntax.TypeAnnotation exposing (TypeAnnotation(..))
 import ElmSyntaxHelpers
 import Json.Encode as Encode exposing (Value)
 import Review.ModuleNameLookupTable as LookupTable exposing (ModuleNameLookupTable)
@@ -354,7 +353,7 @@ matchExpression (Node _ expression) =
             Set.fromList [ "construct:set", "technique:immutable-collection", "technique:sorted-collection" ]
 
         FunctionOrValue [ "Time" ] _ ->
-            Set.fromList [ "construct:date-time" ]
+            Set.singleton "construct:date-time"
 
         FunctionOrValue [ "Dict" ] _ ->
             Set.fromList [ "construct:dictionary", "technique:immutable-collection", "technique:sorted-collection" ]

--- a/src/Tags.elm
+++ b/src/Tags.elm
@@ -11,18 +11,14 @@ import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
 import Set exposing (Set)
 
 
-type alias Tag =
-    String
-
-
 type alias ProjectContext =
-    { tags : Set Tag
+    { tags : Set String
     }
 
 
 type alias ModuleContext =
     { lookupTable : ModuleNameLookupTable
-    , tags : Set Tag
+    , tags : Set String
     }
 
 
@@ -72,7 +68,7 @@ commonModuleVisitor _ context =
     ( [], { context | tags = commonTags } )
 
 
-commonTags : Set Tag
+commonTags : Set String
 commonTags =
     Set.fromList
         [ "paradigm:functional"
@@ -130,7 +126,7 @@ expressionVisitor ((Node range expression) as node) ({ lookupTable, tags } as co
             ( [], { context | tags = Set.union tags (matchExpression node) } )
 
 
-matchExpression : Node Expression -> Set Tag
+matchExpression : Node Expression -> Set String
 matchExpression (Node range expression) =
     case expression of
         FunctionOrValue [ "Set" ] _ ->

--- a/test_data/strain/imperfect_solution/expected_tags.json
+++ b/test_data/strain/imperfect_solution/expected_tags.json
@@ -1,0 +1,5 @@
+[
+  "paradigm:functional",
+  "technique:immutability",
+  "uses:module"
+]

--- a/test_data/strain/imperfect_solution/expected_tags.json
+++ b/test_data/strain/imperfect_solution/expected_tags.json
@@ -1,5 +1,11 @@
 [
+  "construct:boolean",
+  "construct:comment",
+  "construct:list",
+  "construct:logical-not",
   "paradigm:functional",
+  "technique:boolean-logic",
   "technique:immutability",
+  "uses:function-application",
   "uses:module"
 ]

--- a/test_data/strain/perfect_solution/expected_tags.json
+++ b/test_data/strain/perfect_solution/expected_tags.json
@@ -1,5 +1,12 @@
 [
+  "construct:boolean",
+  "construct:if",
+  "construct:lambda",
+  "construct:list",
+  "construct:logical-not",
   "paradigm:functional",
+  "technique:boolean-logic",
   "technique:immutability",
+  "uses:function-application",
   "uses:module"
 ]

--- a/test_data/strain/perfect_solution/expected_tags.json
+++ b/test_data/strain/perfect_solution/expected_tags.json
@@ -1,0 +1,5 @@
+[
+  "paradigm:functional",
+  "technique:immutability",
+  "uses:module"
+]

--- a/test_data/two-fer/imperfect_solution/expected_tags.json
+++ b/test_data/two-fer/imperfect_solution/expected_tags.json
@@ -1,5 +1,19 @@
 [
+  "construct:boolean",
+  "construct:comment",
+  "construct:constructor",
+  "construct:destructuring",
+  "construct:if",
+  "construct:int",
+  "construct:integral-number",
+  "construct:logical-and",
+  "construct:multiply",
+  "construct:pattern-matching",
+  "construct:string",
   "paradigm:functional",
+  "technique:boolean-logic",
   "technique:immutability",
+  "uses:custom-type",
+  "uses:function-application",
   "uses:module"
 ]

--- a/test_data/two-fer/imperfect_solution/expected_tags.json
+++ b/test_data/two-fer/imperfect_solution/expected_tags.json
@@ -1,0 +1,5 @@
+[
+  "paradigm:functional",
+  "technique:immutability",
+  "uses:module"
+]

--- a/test_data/two-fer/perfect_solution/expected_tags.json
+++ b/test_data/two-fer/perfect_solution/expected_tags.json
@@ -1,5 +1,7 @@
 [
+  "construct:string",
   "paradigm:functional",
   "technique:immutability",
+  "uses:function-application",
   "uses:module"
 ]

--- a/test_data/two-fer/perfect_solution/expected_tags.json
+++ b/test_data/two-fer/perfect_solution/expected_tags.json
@@ -1,0 +1,5 @@
+[
+  "paradigm:functional",
+  "technique:immutability",
+  "uses:module"
+]

--- a/tests/ElmSyntaxHelpersTest.elm
+++ b/tests/ElmSyntaxHelpersTest.elm
@@ -50,6 +50,37 @@ hasGenericRecordTests =
         ]
 
 
+hasDestructuringPatternTests : Test
+hasDestructuringPatternTests =
+    describe "hasDestructuringPattern"
+        [ test "no destructuring" <|
+            \_ ->
+                Node.empty (ParenthesizedPattern (Node.empty (ListPattern [ Node.empty UnitPattern ])))
+                    |> ElmSyntaxHelpers.hasDestructuringPattern
+                    |> Expect.equal False
+        , test "tuple destructuring" <|
+            \_ ->
+                Node.empty (TuplePattern [])
+                    |> ElmSyntaxHelpers.hasDestructuringPattern
+                    |> Expect.equal True
+        , test "record destructuring" <|
+            \_ ->
+                Node.empty (RecordPattern [])
+                    |> ElmSyntaxHelpers.hasDestructuringPattern
+                    |> Expect.equal True
+        , test "named destructuring" <|
+            \_ ->
+                Node.empty (NamedPattern { moduleName = [], name = "Thing" } [])
+                    |> ElmSyntaxHelpers.hasDestructuringPattern
+                    |> Expect.equal True
+        , test "uncons destructuring" <|
+            \_ ->
+                Node.empty (UnConsPattern (Node.empty UnitPattern) (Node.empty UnitPattern))
+                    |> ElmSyntaxHelpers.hasDestructuringPattern
+                    |> Expect.equal True
+        ]
+
+
 traversePatternTests : Test
 traversePatternTests =
     describe "traversePattern"

--- a/tests/ElmSyntaxHelpersTest.elm
+++ b/tests/ElmSyntaxHelpersTest.elm
@@ -50,6 +50,34 @@ hasGenericRecordTests =
         ]
 
 
+hasTypedTests : Test
+hasTypedTests =
+    describe "hasTyped"
+        [ test "no typed" <|
+            \_ ->
+                Node.empty
+                    (Tupled
+                        [ Node.empty (FunctionTypeAnnotation (Node.empty Unit) (Node.empty (GenericType "x")))
+                        , Node.empty (Record [ Node.empty ( Node.empty "x", Node.empty Unit ) ])
+                        , Node.empty (Typed (Node.empty ( [ "X" ], "y" )) [])
+                        ]
+                    )
+                    |> ElmSyntaxHelpers.hasTyped [ "X" ] "x"
+                    |> Expect.equal False
+        , test "one typed" <|
+            \_ ->
+                Node.empty
+                    (Tupled
+                        [ Node.empty (FunctionTypeAnnotation (Node.empty Unit) (Node.empty (GenericType "x")))
+                        , Node.empty (Record [ Node.empty ( Node.empty "x", Node.empty Unit ) ])
+                        , Node.empty (Typed (Node.empty ( [ "X" ], "x" )) [])
+                        ]
+                    )
+                    |> ElmSyntaxHelpers.hasTyped [ "X" ] "x"
+                    |> Expect.equal True
+        ]
+
+
 hasDestructuringPatternTests : Test
 hasDestructuringPatternTests =
     describe "hasDestructuringPattern"

--- a/tests/TagsTest.elm
+++ b/tests/TagsTest.elm
@@ -1,0 +1,220 @@
+module TagsTest exposing (tests)
+
+import Comment exposing (CommentType(..))
+import Review.Test
+import Tags
+import Test exposing (Test, describe, test)
+
+
+tests : Test
+tests =
+    describe "TagsTest tests"
+        [ commonTags
+        , expressionTags
+        ]
+
+
+commonTags : Test
+commonTags =
+    let
+        data =
+            """
+[
+    "paradigm:functional",
+    "technique:immutability",
+    "uses:module"
+]
+"""
+    in
+    describe "should always return the initialTags"
+        [ test "for an empty module" <|
+            \() ->
+                "module A exposing (..)"
+                    |> Review.Test.run Tags.commonTagsRule
+                    |> Review.Test.expectDataExtract data
+        , test "for an non-empty module" <|
+            \() ->
+                """
+module TwoFer exposing (twoFer)
+
+twoFer : Maybe String -> String
+twoFer name =
+    "One for "
+        ++ Maybe.withDefault "you" name
+        ++ ", one for me."
+"""
+                    |> Review.Test.run Tags.commonTagsRule
+                    |> Review.Test.expectDataExtract data
+        ]
+
+
+expressionTags : Test
+expressionTags =
+    let
+        commonStart =
+            """
+module A exposing (..)
+
+import Set
+import Dict
+import Random
+import Regex
+import Debug
+     """
+
+        expectData function data =
+            commonStart
+                ++ function
+                |> Review.Test.run Tags.expressionTagsRule
+                |> Review.Test.expectDataExtract data
+    in
+    describe "matching expressions"
+        [ test "using Set function" <|
+            \() ->
+                expectData "f = Set.empty"
+                    "[ \"construct:set\", \"technique:immutable-collection\", \"technique:sorted-collection\" ]"
+        , test "using Dict function" <|
+            \() ->
+                expectData "f = Dict.empty"
+                    "[ \"construct:dictionary\", \"technique:immutable-collection\", \"technique:sorted-collection\" ]"
+        , test "using Random function" <|
+            \() ->
+                expectData "f = Random.constant"
+                    "[ \"technique:randomness\" ]"
+        , test "using Regex function" <|
+            \() ->
+                expectData "f = Regex.fromString"
+                    "[ \"technique:regular-expression\" ]"
+        , test "using inline +" <|
+            \() ->
+                expectData "f a b = a + b"
+                    "[ \"construct:add\" ]"
+        , test "using prefix +" <|
+            \() ->
+                expectData "f = (+)"
+                    "[ \"construct:add\" ]"
+        , test "using inline -" <|
+            \() ->
+                expectData "f a b = a - b"
+                    "[ \"construct:subtract\" ]"
+        , test "using prefix -" <|
+            \() ->
+                expectData "f = (-)"
+                    "[ \"construct:subtract\" ]"
+        , test "using inline *" <|
+            \() ->
+                expectData "f a b = a * b"
+                    "[ \"construct:multiply\" ]"
+        , test "using prefix *" <|
+            \() ->
+                expectData "f = (*)"
+                    "[ \"construct:multiply\" ]"
+        , test "using inline /" <|
+            \() ->
+                expectData "f a b = a / b"
+                    "[ \"construct:divide\" ]"
+        , test "using prefix /" <|
+            \() ->
+                expectData "f = (/)"
+                    "[ \"construct:divide\" ]"
+        , test "using inline //" <|
+            \() ->
+                expectData "f a b = a // b"
+                    "[ \"construct:divide\" ]"
+        , test "using prefix //" <|
+            \() ->
+                expectData "f = (//)"
+                    "[ \"construct:divide\" ]"
+        , test "using inline ==" <|
+            \() ->
+                expectData "f a b = a == b"
+                    "[ \"construct:boolean\", \"construct:equality\", \"technique:equality-comparison\" ]"
+        , test "using prefix ==" <|
+            \() ->
+                expectData "f = (==)"
+                    "[ \"construct:boolean\", \"construct:equality\", \"technique:equality-comparison\" ]"
+        , test "using inline /=" <|
+            \() ->
+                expectData "f a b = a /= b"
+                    "[ \"construct:boolean\", \"construct:inequality\", \"technique:equality-comparison\" ]"
+        , test "using ()" <|
+            \() ->
+                expectData "f = ()"
+                    "[ \"uses:unit\" ]"
+        , test "using float" <|
+            \() ->
+                expectData "f = 3.14"
+                    "[ \"construct:float\", \"construct:floating-point-number\" ]"
+        , test "using float scientific notation" <|
+            \() ->
+                expectData "f = 314e-2"
+                    "[ \"construct:float\", \"construct:floating-point-number\" ]"
+        , test "using int" <|
+            \() ->
+                expectData "f = 42"
+                    "[ \"construct:int\", \"construct:integral-number\" ]"
+        , test "using int with hex notation" <|
+            \() ->
+                expectData "f = 0x42"
+                    "[ \"construct:hexadecimal-number\", \"construct:int\", \"construct:integral-number\" ]"
+        , test "using negation and int" <|
+            \() ->
+                expectData "f = -42"
+                    "[ \"construct:int\", \"construct:integral-number\", \"construct:unary-minus\" ]"
+        , test "using a string literal" <|
+            \() ->
+                expectData "f = \"hello\""
+                    "[ \"construct:string\" ]"
+        , test "using mutiline string literal" <|
+            \() ->
+                expectData "f = \"\"\"\nhello\nworld\"\"\""
+                    "[ \"construct:multiline-string\", \"construct:string\" ]"
+        , test "using lambda" <|
+            \() ->
+                expectData "f x = (\\_ -> x)"
+                    "[ \"construct:lambda\" ]"
+        , test "using if block" <|
+            \() ->
+                expectData "f x y z = if x then y else z"
+                    "[ \"construct:boolean\", \"construct:if\" ]"
+        , test "let block without proper destructuring" <|
+            \() ->
+                expectData "f x y = let z = y in z"
+                    "[]"
+        , test "let block with tuple destructuring" <|
+            \() ->
+                expectData "f y = let (a, b) = y in a"
+                    "[ \"construct:pattern-matching\", \"uses:destructure\"]"
+        , test "let block with record destructuring" <|
+            \() ->
+                expectData "f y = let {a, b} = y in a"
+                    "[ \"construct:pattern-matching\", \"uses:destructure\"]"
+        , test "let block with uncons destructuring" <|
+            \() ->
+                expectData "f y = let a :: b = y in a"
+                    "[ \"construct:pattern-matching\", \"uses:destructure\"]"
+        , test "let block with named destructuring" <|
+            \() ->
+                expectData "f y = let Thing a = y in a"
+                    "[ \"construct:pattern-matching\", \"uses:destructure\"]"
+        , test "let block with nested destructuring" <|
+            \() ->
+                expectData "f y = let (Thing a) = y in a"
+                    "[ \"construct:pattern-matching\", \"uses:destructure\"]"
+        , test "let block with a function with record destructuring" <|
+            \() ->
+                expectData "f y = let f2 { a } = a in f2 y"
+                    "[ \"construct:pattern-matching\", \"uses:destructure\"]"
+        , test "let block with a function with tuple destructuring" <|
+            \() ->
+                expectData "f y = let f2 (a, b) = a in f2 y"
+                    "[ \"construct:pattern-matching\", \"uses:destructure\"]"
+        , test "let block with a function with uncons destructuring" <|
+            \() ->
+                expectData "f y = let f2 (a :: b) = a in f2 y"
+                    "[ \"construct:pattern-matching\", \"uses:destructure\"]"
+        , test "let block with a function with named destructuring" <|
+            \() ->
+                expectData "f y = let f2 (Thing a) = a in f2 y"
+                    "[ \"construct:pattern-matching\", \"uses:destructure\"]"
+        ]

--- a/tests/TagsTest.elm
+++ b/tests/TagsTest.elm
@@ -73,7 +73,9 @@ expectData function data =
 expressionTypeTags : Test
 expressionTypeTags =
     describe "matching expression types"
-        [ test "FunctionOrValue is too general for a tag" <|
+        [ test "Type constructors " <|
+            \() -> expectData "f = Just" "[ \"construct:constructor\"]"
+        , test "other functions and values too general for a tag" <|
             \() -> expectData "f x = x" "[]"
         , test "ParenthesizedExpression is too general for a tag" <|
             \() -> expectData "f x = (x)" "[]"
@@ -174,6 +176,17 @@ expressionTags =
             \() ->
                 expectData "f = Array.empty"
                     "[ \"construct:array\", \"technique:immutable-collection\" ]"
+        , test "using Bytes function" <|
+            \() ->
+                expectData "f = Bytes.width"
+                    "[ \"construct:byte\" ]"
+        , test "using Bytes.Encode function" <|
+            \() ->
+                expectData "f = Bytes.Encode.encode"
+                    "[ \"construct:byte\" ]"
+        , test "using List function" <|
+            \() ->
+                expectData "f = List.all" "[ \"construct:list\" ]"
         , test "using Set function" <|
             \() ->
                 expectData "f = Set.empty"
@@ -286,8 +299,40 @@ expressionTags =
             \() ->
                 expectData "f y = let f2 (Thing a) = a in f2"
                     "[ \"construct:assignment\", \"construct:destructuring\", \"construct:pattern-matching\"]"
-        , test "function application" <|
+        , test "using inline &&" <|
             \() ->
-                expectData "f x y = x y"
-                    "[ \"uses:function-application\"]"
+                expectData "f a b = a && b"
+                    "[ \"construct:boolean\", \"construct:logical-and\", \"technique:boolean-logic\", \"uses:function-application\"]"
+        , test "using prefix &&" <|
+            \() ->
+                expectData "f = (&&)"
+                    "[ \"construct:boolean\", \"construct:logical-and\", \"technique:boolean-logic\", \"uses:prefix-operator\" ]"
+        , test "using inline ||" <|
+            \() ->
+                expectData "f a b = a || b"
+                    "[ \"construct:boolean\", \"construct:logical-or\", \"technique:boolean-logic\", \"uses:function-application\"]"
+        , test "using prefix ||" <|
+            \() ->
+                expectData "f = (||)"
+                    "[ \"construct:boolean\", \"construct:logical-or\", \"technique:boolean-logic\", \"uses:prefix-operator\" ]"
+        , test "using not" <|
+            \() ->
+                expectData "f x = not x"
+                    "[ \"construct:boolean\", \"construct:logical-not\", \"technique:boolean-logic\", \"uses:function-application\" ]"
+        , test "using xor" <|
+            \() ->
+                expectData "f x y = xor x y"
+                    "[ \"construct:boolean\", \"technique:boolean-logic\", \"uses:function-application\" ]"
+        , test "using True" <|
+            \() -> expectData "f = True" "[ \"construct:boolean\", \"construct:constructor\" ]"
+        , test "using False" <|
+            \() -> expectData "f = False" "[ \"construct:boolean\", \"construct:constructor\" ]"
+        , test "using isNaN" <|
+            \() ->
+                expectData "f x = isNaN x"
+                    "[ \"construct:boolean\", \"construct:float\", \"construct:floating-point-number\", \"uses:function-application\" ]"
+        , test "using isInfinite" <|
+            \() ->
+                expectData "f x = isInfinite x"
+                    "[ \"construct:boolean\", \"construct:float\", \"construct:floating-point-number\", \"uses:function-application\" ]"
         ]

--- a/tests/TagsTest.elm
+++ b/tests/TagsTest.elm
@@ -10,6 +10,7 @@ tests : Test
 tests =
     describe "TagsTest tests"
         [ commonTags
+        , commentsTags
         , expressionTypeTags
         , expressionTags
         ]
@@ -46,6 +47,55 @@ twoFer name =
 """
                     |> Review.Test.run Tags.commonTagsRule
                     |> Review.Test.expectDataExtract data
+        ]
+
+
+commentsTags : Test
+commentsTags =
+    describe "comments"
+        [ test "module documentation" <|
+            \() ->
+                """
+module A exposing (..)
+{-| This a module documentation blurb
+-}
+
+f x = x
+"""
+                    |> Review.Test.run Tags.expressionTagsRule
+                    |> Review.Test.expectDataExtract "[ \"construct:comment\", \"construct:documentation\" ]"
+        , test "top level comment" <|
+            \() ->
+                """
+module A exposing (..)
+
+-- this is a top level comment
+f x = x
+"""
+                    |> Review.Test.run Tags.expressionTagsRule
+                    |> Review.Test.expectDataExtract "[ \"construct:comment\" ]"
+        , test "internal comment" <|
+            \() ->
+                """
+module A exposing (..)
+
+f x =
+    -- this is an internal comment
+    x
+"""
+                    |> Review.Test.run Tags.expressionTagsRule
+                    |> Review.Test.expectDataExtract "[ \"construct:comment\" ]"
+        , test "function documentation" <|
+            \() ->
+                """
+module A exposing (..)
+
+{-| This is a function documentation comment
+-}
+f x = x
+"""
+                    |> Review.Test.run Tags.expressionTagsRule
+                    |> Review.Test.expectDataExtract "[ \"construct:comment\", \"construct:documentation\" ]"
         ]
 
 

--- a/tests/TagsTest.elm
+++ b/tests/TagsTest.elm
@@ -1,6 +1,5 @@
 module TagsTest exposing (tests)
 
-import Comment exposing (CommentType(..))
 import Review.Test
 import Tags
 import Test exposing (Test, describe, test)


### PR DESCRIPTION
Dear @mpizenberg, @ceddlyburge  and @ErikSchierboom,

Following our (fun and productive) discussion about tags, I came up with a prototype for the tagging mechanism, using elm-review's data extractors, which seems like a perfect fit, I have been able to add some tags very quickly.

Some comments:

- All of the tagging logic is in `src/Tags.elm`. If you are not familiar with elm-review, you can ignore the boilerplate, the core function is `matchExpression` and is easy to understand.
- For now, I have added random tags, some because they were easy, and because they were a bit more subtle (`LetExpression`, multiline strings). 
- There is one rule `commonTagsRule` that always returns the same tags `commonTags` for any project.
- For more complex traversals, for things like recursion, I would recommend adding a separate rule.
- I don't know if we want to have more structure around the rules, for now one rule for each type of elm-syntax type (project, module, expressions, function declarations...) seems the most natural fit.
- I have been testing every case so far, and I have found bugs thanks to it
- I haven't added smoke tests for now, but it will be simple, we can do it once we have more tags in, they will be easy to add.- @ErikSchierboom I'm not sure if it can go live or not in this incomplete state. Is there a mechanism for going live? The `tags.json` files will be created from this PR on anyway.

I'd be happy to hear feedback about any of it.