### PR TITLE
Add rule for concept exercise `lucians-luscious-lasagna`

### DIFF
--- a/src/Exercise/LuciansLusciousLasagna.elm
+++ b/src/Exercise/LuciansLusciousLasagna.elm
@@ -1,0 +1,26 @@
+module Exercise.LuciansLusciousLasagna exposing (reuseFunctions, ruleConfig)
+
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Review.Rule exposing (Rule)
+import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
+
+
+ruleConfig : RuleConfig
+ruleConfig =
+    { restrictToFiles = Just [ "src/LuciansLusciousLasagna.elm" ]
+    , rules =
+        [ CustomRule reuseFunctions
+            (Comment "elm.lucians-luscious-lasagna.reuse_functions" Essential Dict.empty)
+        ]
+    }
+
+
+reuseFunctions : Comment -> Rule
+reuseFunctions =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "elapsedTimeInMinutes"
+        , findExpressions = [ FromSameModule "preparationTimeInMinutes" ]
+        , find = Some
+        }

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -11,6 +11,7 @@ import Exercise.BlorkemonCards
 import Exercise.CustomSet
 import Exercise.GottaSnatchEmAll
 import Exercise.ListOps
+import Exercise.LuciansLusciousLasagna
 import Exercise.MariosMarvellousLasagna
 import Exercise.MazeMaker
 import Exercise.Strain
@@ -47,6 +48,7 @@ ruleConfigs =
     , Exercise.TisburyTreasureHunt.ruleConfig
     , Exercise.GottaSnatchEmAll.ruleConfig
     , Exercise.AnnalynsInfiltration.ruleConfig
+    , Exercise.LuciansLusciousLasagna.ruleConfig
 
     -- Practice Exercises
     , Exercise.Strain.ruleConfig

--- a/tests/Exercise/LuciansLusciousLasagnaTest.elm
+++ b/tests/Exercise/LuciansLusciousLasagnaTest.elm
@@ -1,0 +1,69 @@
+module Exercise.LuciansLusciousLasagnaTest exposing (tests)
+
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Exercise.LuciansLusciousLasagna as LuciansLusciousLasagna
+import Review.Rule exposing (Rule)
+import Review.Test
+import RuleConfig
+import Test exposing (Test, describe, test)
+import TestHelper
+
+
+tests : Test
+tests =
+    describe "LuciansLusciousLasagnaTest"
+        [ exemplar
+        , doesNotReuseFunction
+        ]
+
+
+rules : List Rule
+rules =
+    LuciansLusciousLasagna.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
+
+
+exemplar : Test
+exemplar =
+    test "should not report anything for the exemplar" <|
+        \() ->
+            TestHelper.expectNoErrorsForRules rules
+                """
+module LuciansLusciousLasagna exposing (elapsedTimeInMinutes, expectedMinutesInOven, preparationTimeInMinutes)
+
+expectedMinutesInOven =
+    40
+
+preparationTimeInMinutes layers =
+    2 * layers
+
+elapsedTimeInMinutes layers passedAlready =
+    passedAlready + preparationTimeInMinutes layers
+"""
+
+
+doesNotReuseFunction : Test
+doesNotReuseFunction =
+    let
+        comment =
+            Comment "elm.lucians-luscious-lasagna.reuse_functions" Essential Dict.empty
+    in
+    test "canFreePrisoner doesn't use boolean operators" <|
+        \() ->
+            """
+module LuciansLusciousLasagna exposing (elapsedTimeInMinutes, expectedMinutesInOven, preparationTimeInMinutes)
+
+expectedMinutesInOven =
+    40
+
+preparationTimeInMinutes layers =
+    2 * layers
+
+elapsedTimeInMinutes layers passedAlready =
+    passedAlready + 2 * layers
+"""
+                |> Review.Test.run (LuciansLusciousLasagna.reuseFunctions comment)
+                |> Review.Test.expectErrors
+                    [ TestHelper.createExpectedErrorUnder comment "elapsedTimeInMinutes"
+                        |> Review.Test.atExactly { start = { row = 10, column = 1 }, end = { row = 10, column = 21 } }
+                    ]

--- a/tests/Exercise/LuciansLusciousLasagnaTest.elm
+++ b/tests/Exercise/LuciansLusciousLasagnaTest.elm
@@ -48,7 +48,7 @@ doesNotReuseFunction =
         comment =
             Comment "elm.lucians-luscious-lasagna.reuse_functions" Essential Dict.empty
     in
-    test "canFreePrisoner doesn't use boolean operators" <|
+    test "elapsedTimeInMinutes does not use preparationTimeInMinutes" <|
         \() ->
             """
 module LuciansLusciousLasagna exposing (elapsedTimeInMinutes, expectedMinutesInOven, preparationTimeInMinutes)


### PR DESCRIPTION
Closes #16 
[Sister PR here](https://github.com/exercism/website-copy/pull/2303).

Doesn't get simpler than this one.

The issue mentions "Verify that the whitespace adheres to community defaults" but that's not really doable, and not really fair in an environment without elm-format.