### PR TITLE
Remove duplicate comments

### DIFF
--- a/src/Comment.elm
+++ b/src/Comment.elm
@@ -75,7 +75,9 @@ aggregateComments : List Comment -> Summary
 aggregateComments comments =
     let
         sortedComments =
-            List.sortBy commentTypeShowOrder comments
+            comments
+                |> List.Extra.unique
+                |> List.sortBy commentTypeShowOrder
 
         ( message, extraComments ) =
             case List.map .commentType comments |> List.Extra.minimumBy commentTypeSummaryOrder of

--- a/tests/CommentTest.elm
+++ b/tests/CommentTest.elm
@@ -120,9 +120,9 @@ aggregateCommentsTest =
         , test "order of comments in summary is fixed" <|
             \() ->
                 Expect.equal
-                    (Comment.aggregateComments [ essential, informative, celebratory, actionable, informative ])
+                    (Comment.aggregateComments [ essential, informative, celebratory, actionable ])
                     (Summary "Check the comments for things to fix.\u{202F}🛠 "
-                        [ celebratory, essential, actionable, informative, informative, Comment.feedbackComment ]
+                        [ celebratory, essential, actionable, informative, Comment.feedbackComment ]
                     )
         , test "secondary order is alphabetical, but feedback is always last" <|
             \() ->
@@ -147,6 +147,13 @@ aggregateCommentsTest =
                         , informative
                         , Comment.feedbackComment
                         ]
+                    )
+        , test "duplicate comments are removed" <|
+            \() ->
+                Expect.equal
+                    (Comment.aggregateComments [ essential, essential, celebratory, celebratory ])
+                    (Summary "Check the comments for things to fix.\u{202F}🛠 "
+                        [ celebratory, essential, Comment.feedbackComment ]
                     )
         ]
 


### PR DESCRIPTION
I realized that in some cases, we could send duplicate comments, for example when relying on external rules.
I'm not sure what the Exercism interface does with duplicate comments, but better not send them in the first place.