### PR TITLE
Add rule for practice exercise `sieve`

### DIFF
--- a/src/Exercise/Sieve.elm
+++ b/src/Exercise/Sieve.elm
@@ -1,4 +1,4 @@
-module Exercise.Sieve exposing (doNotUseDivision, doNotUseModulo, ruleConfig)
+module Exercise.Sieve exposing (doNotUseDivisionOrModulo, ruleConfig)
 
 import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
 import Comment exposing (Comment, CommentType(..))
@@ -11,27 +11,21 @@ ruleConfig : RuleConfig
 ruleConfig =
     { restrictToFiles = Just [ "src/Sieve.elm" ]
     , rules =
-        [ CustomRule doNotUseDivision
-            (Comment "elm.sieve.do_not_use_division" Essential Dict.empty)
-        , CustomRule doNotUseModulo
-            (Comment "elm.sieve.do_not_use_modulo" Essential Dict.empty)
+        [ CustomRule doNotUseDivisionOrModulo
+            (Comment "elm.sieve.do_not_use_division_or_modulo" Essential Dict.empty)
         ]
     }
 
 
-doNotUseDivision : Comment -> Rule
-doNotUseDivision =
+doNotUseDivisionOrModulo : Comment -> Rule
+doNotUseDivisionOrModulo =
     Analyzer.functionCalls
         { calledFrom = Anywhere
-        , findExpressions = [ Operator "//", Operator "/" ]
-        , find = None
-        }
-
-
-doNotUseModulo : Comment -> Rule
-doNotUseModulo =
-    Analyzer.functionCalls
-        { calledFrom = Anywhere
-        , findExpressions = [ FromExternalModule [ "Basics" ] "modBy", FromExternalModule [ "Basics" ] "remainderBy" ]
+        , findExpressions =
+            [ Operator "//"
+            , Operator "/"
+            , FromExternalModule [ "Basics" ] "modBy"
+            , FromExternalModule [ "Basics" ] "remainderBy"
+            ]
         , find = None
         }

--- a/src/Exercise/Sieve.elm
+++ b/src/Exercise/Sieve.elm
@@ -1,0 +1,37 @@
+module Exercise.Sieve exposing (doNotUseDivision, doNotUseModulo, ruleConfig)
+
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Review.Rule exposing (Rule)
+import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
+
+
+ruleConfig : RuleConfig
+ruleConfig =
+    { restrictToFiles = Just [ "src/Sieve.elm" ]
+    , rules =
+        [ CustomRule doNotUseDivision
+            (Comment "elm.sieve.do_not_use_division" Essential Dict.empty)
+        , CustomRule doNotUseModulo
+            (Comment "elm.sieve.do_not_use_modulo" Essential Dict.empty)
+        ]
+    }
+
+
+doNotUseDivision : Comment -> Rule
+doNotUseDivision =
+    Analyzer.functionCalls
+        { calledFrom = Anywhere
+        , findExpressions = [ Operator "//", Operator "/" ]
+        , find = None
+        }
+
+
+doNotUseModulo : Comment -> Rule
+doNotUseModulo =
+    Analyzer.functionCalls
+        { calledFrom = Anywhere
+        , findExpressions = [ FromExternalModule [ "Basics" ] "modBy", FromExternalModule [ "Basics" ] "remainderBy" ]
+        , find = None
+        }

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -15,6 +15,7 @@ import Exercise.LuciansLusciousLasagna
 import Exercise.MariosMarvellousLasagna
 import Exercise.MazeMaker
 import Exercise.RolePlayingGame
+import Exercise.Sieve
 import Exercise.Strain
 import Exercise.TicketPlease
 import Exercise.TisburyTreasureHunt
@@ -61,6 +62,7 @@ ruleConfigs =
     , Exercise.CustomSet.ruleConfig
     , Exercise.ListOps.ruleConfig
     , Exercise.ZebraPuzzle.ruleConfig
+    , Exercise.Sieve.ruleConfig
     ]
 
 

--- a/tests/Exercise/SieveTest.elm
+++ b/tests/Exercise/SieveTest.elm
@@ -14,8 +14,7 @@ tests : Test
 tests =
     describe "SieveTest"
         [ exampleSolution
-        , usingDivision
-        , usingModulo
+        , usingDivisionOrModulo
         ]
 
 
@@ -101,11 +100,11 @@ runSieve maybePrime sieve =
 """
 
 
-usingDivision : Test
-usingDivision =
+usingDivisionOrModulo : Test
+usingDivisionOrModulo =
     let
         comment =
-            Comment "elm.sieve.do_not_use_division" Essential Dict.empty
+            Comment "elm.sieve.do_not_use_division_or_modulo" Essential Dict.empty
     in
     describe "solutions that use division" <|
         [ test "using (/)" <|
@@ -127,7 +126,7 @@ run smallPrimes list =
                 rest
                 |> run newPrimes
 """
-                    |> Review.Test.run (Sieve.doNotUseDivision comment)
+                    |> Review.Test.run (Sieve.doNotUseDivisionOrModulo comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder comment "toFloat n / toFloat p"
                             |> Review.Test.atExactly { start = { row = 14, column = 85 }, end = { row = 14, column = 106 } }
@@ -151,20 +150,10 @@ run smallPrimes list =
                 rest
                 |> run newPrimes
 """
-                    |> Review.Test.run (Sieve.doNotUseDivision comment)
+                    |> Review.Test.run (Sieve.doNotUseDivisionOrModulo comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder comment "n // p" ]
-        ]
-
-
-usingModulo : Test
-usingModulo =
-    let
-        comment =
-            Comment "elm.sieve.do_not_use_modulo" Essential Dict.empty
-    in
-    describe "solutions that use modulo" <|
-        [ test "using modBy" <|
+        , test "using modBy" <|
             \() ->
                 """
 module Sieve exposing (primes)
@@ -183,7 +172,7 @@ run smallPrimes list =
                 rest
                 |> run newPrimes
 """
-                    |> Review.Test.run (Sieve.doNotUseModulo comment)
+                    |> Review.Test.run (Sieve.doNotUseDivisionOrModulo comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder comment "modBy" ]
         , test "using remainderBy" <|
@@ -205,7 +194,7 @@ run smallPrimes list =
                 rest
                 |> run newPrimes
 """
-                    |> Review.Test.run (Sieve.doNotUseModulo comment)
+                    |> Review.Test.run (Sieve.doNotUseDivisionOrModulo comment)
                     |> Review.Test.expectErrors
                         [ TestHelper.createExpectedErrorUnder comment "remainderBy" ]
         ]

--- a/tests/Exercise/SieveTest.elm
+++ b/tests/Exercise/SieveTest.elm
@@ -1,0 +1,211 @@
+module Exercise.SieveTest exposing (tests)
+
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Exercise.Sieve as Sieve
+import Review.Rule exposing (Rule)
+import Review.Test
+import RuleConfig
+import Test exposing (Test, describe, test)
+import TestHelper
+
+
+tests : Test
+tests =
+    describe "SieveTest"
+        [ exampleSolution
+        , usingDivision
+        , usingModulo
+        ]
+
+
+rules : List Rule
+rules =
+    Sieve.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
+
+
+exampleSolution : Test
+exampleSolution =
+    test "should not report anything for the example solution" <|
+        \() ->
+            TestHelper.expectNoErrorsForRules rules
+                """
+module Sieve exposing (primes)
+
+import Array exposing (Array)
+
+
+primes : Int -> List Int
+primes limit =
+    let
+        -- an array, with indices from 0 until limit, each with a Bool value representing primeness
+        initialSieve =
+            Array.initialize (limit + 1)
+                (\\n ->
+                    if n < 2 then
+                        False
+
+                    else
+                        True
+                )
+
+        initialPrime =
+            Just 2
+    in
+    runSieve initialPrime initialSieve
+        |> Array.toIndexedList
+        |> List.filterMap
+            (\\( index, isPrime ) ->
+                if isPrime then
+                    Just index
+
+                else
+                    Nothing
+            )
+
+
+runSieve : Maybe Int -> Array Bool -> Array Bool
+runSieve maybePrime sieve =
+    case maybePrime of
+        Nothing ->
+            sieve
+
+        Just prime ->
+            let
+                removeMultiples : Int -> Array Bool -> Array Bool
+                removeMultiples multiple =
+                    if multiple > Array.length sieve then
+                        identity
+
+                    else
+                        Array.set multiple False
+                            >> removeMultiples (multiple + prime)
+
+                sieveWithPrimeMultipleRemoved : Array Bool
+                sieveWithPrimeMultipleRemoved =
+                    removeMultiples (2 * prime) sieve
+
+                findNextPrime : Int -> Maybe Int
+                findNextPrime index =
+                    case Array.get index sieveWithPrimeMultipleRemoved of
+                        Nothing ->
+                            Nothing
+
+                        Just True ->
+                            Just index
+
+                        Just False ->
+                            findNextPrime (index + 1)
+            in
+            runSieve (findNextPrime (prime + 1)) sieveWithPrimeMultipleRemoved
+"""
+
+
+usingDivision : Test
+usingDivision =
+    let
+        comment =
+            Comment "elm.sieve.do_not_use_division" Essential Dict.empty
+    in
+    describe "solutions that use division" <|
+        [ test "using (/)" <|
+            \() ->
+                """
+module Sieve exposing (primes)
+
+primes : Int -> List Int
+primes limit = run [] (List.range 2 limit)
+
+run smallPrimes list =
+    case list of
+        [] -> List.reverse smallPrimes
+        prime :: rest ->
+            let newPrimes = prime :: smallPrimes
+            in
+            List.filterMap
+                (\\n -> if List.any (\\p -> ceiling (toFloat n / toFloat p) == floor (toFloat n / toFloat p)) newPrimes then Nothing else Just n)
+                rest
+                |> run newPrimes
+"""
+                    |> Review.Test.run (Sieve.doNotUseDivision comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "toFloat n / toFloat p"
+                            |> Review.Test.atExactly { start = { row = 14, column = 85 }, end = { row = 14, column = 106 } }
+                        ]
+        , test "using (//)" <|
+            \() ->
+                """
+module Sieve exposing (primes)
+
+primes : Int -> List Int
+primes limit = run [] (List.range 2 limit)
+
+run smallPrimes list =
+    case list of
+        [] -> List.reverse smallPrimes
+        prime :: rest ->
+            let newPrimes = prime :: smallPrimes
+            in
+            List.filterMap
+                (\\n -> if List.any (\\p -> (n // p) * p == n) newPrimes then Nothing else Just n)
+                rest
+                |> run newPrimes
+"""
+                    |> Review.Test.run (Sieve.doNotUseDivision comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "n // p" ]
+        ]
+
+
+usingModulo : Test
+usingModulo =
+    let
+        comment =
+            Comment "elm.sieve.do_not_use_modulo" Essential Dict.empty
+    in
+    describe "solutions that use modulo" <|
+        [ test "using modBy" <|
+            \() ->
+                """
+module Sieve exposing (primes)
+
+primes : Int -> List Int
+primes limit = run [] (List.range 2 limit)
+
+run smallPrimes list =
+    case list of
+        [] -> List.reverse smallPrimes
+        prime :: rest ->
+            let newPrimes = prime :: smallPrimes
+            in
+            List.filterMap
+                (\\n -> if List.any (\\p -> modBy p n == 0) newPrimes then Nothing else Just n)
+                rest
+                |> run newPrimes
+"""
+                    |> Review.Test.run (Sieve.doNotUseModulo comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "modBy" ]
+        , test "using remainderBy" <|
+            \() ->
+                """
+module Sieve exposing (primes)
+
+primes : Int -> List Int
+primes limit = run [] (List.range 2 limit)
+
+run smallPrimes list =
+    case list of
+        [] -> List.reverse smallPrimes
+        prime :: rest ->
+            let newPrimes = prime :: smallPrimes
+            in
+            List.filterMap
+                (\\n -> if List.any (\\p -> remainderBy p n == 0) newPrimes then Nothing else Just n)
+                rest
+                |> run newPrimes
+"""
+                    |> Review.Test.run (Sieve.doNotUseModulo comment)
+                    |> Review.Test.expectErrors
+                        [ TestHelper.createExpectedErrorUnder comment "remainderBy" ]
+        ]

--- a/tests/Exercise/SieveTest.elm
+++ b/tests/Exercise/SieveTest.elm
@@ -39,8 +39,7 @@ primes limit =
     let
         -- an array, with indices from 0 until limit, each with a Bool value representing primeness
         initialSieve =
-            Array.initialize (limit + 1) (
- -> n >= 2)
+            Array.initialize (limit + 1) (\\n -> n >= 2)
 
         initialPrime =
             Just 2

--- a/tests/Exercise/SieveTest.elm
+++ b/tests/Exercise/SieveTest.elm
@@ -39,14 +39,8 @@ primes limit =
     let
         -- an array, with indices from 0 until limit, each with a Bool value representing primeness
         initialSieve =
-            Array.initialize (limit + 1)
-                (\\n ->
-                    if n < 2 then
-                        False
-
-                    else
-                        True
-                )
+            Array.initialize (limit + 1) (
+ -> n >= 2)
 
         initialPrime =
             Just 2


### PR DESCRIPTION
[Sister PR over here](https://github.com/exercism/website-copy/pull/2329).

The rule is pretty simple, there are two division in Elm (integer, float) and two modulo functions, disallow them all.
It's also worth doing, seeing how the example of "wrong" solutions are like 3x smaller than the official one.

@exercism/maintainers-admin I wonder if we are too late for @ErikSchierboom to approve this PR