### PR TITLE
Add analysis for concept exercise `kurokos-clock`

### DIFF
--- a/.github/workflows/elm_tests.yml
+++ b/.github/workflows/elm_tests.yml
@@ -16,7 +16,7 @@ jobs:
       # Re-use node_modules between runs until package.json or package-lock.json changes.
       - name: Cache node_modules
         id: cache-node_modules
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@7de21022a7b6824c106a9847befcbd8154b45b6a
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('package.json', 'package-lock.json') }}
@@ -28,7 +28,7 @@ jobs:
       # review/elm.json changes. The Elm compiler saves downloaded Elm packages
       # to ~/.elm, and elm-tooling saves downloaded tool executables there.
       - name: Cache ~/.elm
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@7de21022a7b6824c106a9847befcbd8154b45b6a
         with:
           path: ~/.elm
           key: elm-${{ hashFiles('elm-tooling.json', 'elm.json', 'review/elm.json') }}
@@ -83,7 +83,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-node_modules
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@7de21022a7b6824c106a9847befcbd8154b45b6a
         with:
           path: node_modules
           key: node_modules-${{ hashFiles('package.json', 'package-lock.json') }}
@@ -92,7 +92,7 @@ jobs:
             node_modules-
 
       - name: Cache ~/.elm
-        uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7
+        uses: actions/cache@7de21022a7b6824c106a9847befcbd8154b45b6a
         with:
           path: ~/.elm
           key: elm-${{ hashFiles('elm-tooling.json', 'elm.json', 'review/elm.json') }}

--- a/src/Exercise/KurokosClock.elm
+++ b/src/Exercise/KurokosClock.elm
@@ -1,0 +1,28 @@
+module Exercise.KurokosClock exposing (ruleConfig, usesShowLocalDateAndShowLocalTime)
+
+import Analyzer exposing (CalledExpression(..), CalledFrom(..), Find(..))
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Review.Rule exposing (Rule)
+import RuleConfig exposing (AnalyzerRule(..), RuleConfig)
+
+
+ruleConfig : RuleConfig
+ruleConfig =
+    { restrictToFiles = Just [ "src/KurokosClock.elm" ]
+    , rules =
+        [ CustomRule usesShowLocalDateAndShowLocalTime (Comment "elm.kurokos-clock.use_showLocalDate_and_showLocalTime" Essential Dict.empty)
+        ]
+    }
+
+
+usesShowLocalDateAndShowLocalTime : Comment -> Rule
+usesShowLocalDateAndShowLocalTime =
+    Analyzer.functionCalls
+        { calledFrom = TopFunction "showDateTime"
+        , findExpressions =
+            [ FromSameModule "showLocalDate"
+            , FromSameModule "showLocalTime"
+            ]
+        , find = All
+        }

--- a/src/ReviewConfig.elm
+++ b/src/ReviewConfig.elm
@@ -10,6 +10,7 @@ import Exercise.BettysBikeShop
 import Exercise.BlorkemonCards
 import Exercise.CustomSet
 import Exercise.GottaSnatchEmAll
+import Exercise.KurokosClock
 import Exercise.ListOps
 import Exercise.LuciansLusciousLasagna
 import Exercise.MariosMarvellousLasagna
@@ -56,6 +57,7 @@ ruleConfigs =
     , Exercise.GottaSnatchEmAll.ruleConfig
     , Exercise.AnnalynsInfiltration.ruleConfig
     , Exercise.LuciansLusciousLasagna.ruleConfig
+    , Exercise.KurokosClock.ruleConfig
 
     -- Practice Exercises
     , Exercise.Strain.ruleConfig

--- a/tests/Exercise/KurokosClockTest.elm
+++ b/tests/Exercise/KurokosClockTest.elm
@@ -1,0 +1,407 @@
+module Exercise.KurokosClockTest exposing (tests)
+
+import Comment exposing (Comment, CommentType(..))
+import Dict
+import Exercise.KurokosClock as KurokosClock
+import Review.Rule exposing (Rule)
+import Review.Test
+import RuleConfig
+import Test exposing (Test, describe, test)
+import TestHelper
+
+
+tests =
+    describe "KurokosClockTest"
+        [ exampleSolution
+        , missingShowLocalDate
+        , missingShowLocalTime
+        ]
+
+
+rules : List Rule
+rules =
+    KurokosClock.ruleConfig |> .rules |> List.map RuleConfig.analyzerRuleToRule
+
+
+exampleSolution : Test
+exampleSolution =
+    test "should not report anything for the example solution" <|
+        \() ->
+            TestHelper.expectNoErrorsForRules rules
+                """
+module KurokosClock exposing (Locale(..), showDateTime, showLocalDate, showLocalTime)
+
+import Time exposing (Month(..), Posix, Zone)
+
+
+type Locale
+    = US
+    | JP
+
+
+showLocalDate : Locale -> Int -> Month -> Int -> String
+showLocalDate locale year month day =
+    let
+        yearStr =
+            String.fromInt year
+
+        monthStr =
+            month |> monthToInt |> String.fromInt
+
+        dayStr =
+            String.fromInt day
+    in
+    case locale of
+        US ->
+            monthStr ++ "/" ++ dayStr ++ "/" ++ yearStr
+
+        JP ->
+            yearStr ++ "年" ++ monthStr ++ "月" ++ dayStr ++ "日"
+
+
+showLocalTime : Locale -> Int -> Int -> String
+showLocalTime locale hour minute =
+    let
+        minuteStr =
+            String.fromInt minute
+    in
+    case locale of
+        US ->
+            let
+                period =
+                    if hour >= 12 then
+                        "PM"
+
+                    else
+                        "AM"
+
+                hour12 =
+                    case modBy 12 hour of
+                        0 ->
+                            12
+
+                        h ->
+                            h
+            in
+            String.fromInt hour12 ++ ":" ++ String.padLeft 2 '0' minuteStr ++ " " ++ period
+
+        JP ->
+            String.fromInt hour ++ "時" ++ minuteStr ++ "分"
+
+
+showDateTime : Locale -> Zone -> Posix -> String
+showDateTime locale zone posix =
+    let
+        year =
+            Time.toYear zone posix
+
+        month =
+            Time.toMonth zone posix
+
+        day =
+            Time.toDay zone posix
+
+        hour =
+            Time.toHour zone posix
+
+        minute =
+            Time.toMinute zone posix
+    in
+    case locale of
+        US ->
+            showLocalDate locale year month day ++ " " ++ showLocalTime locale hour minute
+
+        JP ->
+            showLocalDate locale year month day ++ showLocalTime locale hour minute
+
+
+monthToInt : Month -> Int
+monthToInt month =
+    case month of
+        Jan ->
+            1
+
+        Feb ->
+            2
+
+        Mar ->
+            3
+
+        Apr ->
+            4
+
+        May ->
+            5
+
+        Jun ->
+            6
+
+        Jul ->
+            7
+
+        Aug ->
+            8
+
+        Sep ->
+            9
+
+        Oct ->
+            10
+
+        Nov ->
+            11
+
+        Dec ->
+            12
+"""
+
+
+missingShowLocalDate : Test
+missingShowLocalDate =
+    let
+        comment =
+            Comment "elm.kurokos-clock.use_showLocalDate_and_showLocalTime" Essential Dict.empty
+    in
+    test "not using showLocalDate" <|
+        \() ->
+            """
+module KurokosClock exposing (Locale(..), showDateTime, showLocalDate, showLocalTime)
+
+import Time exposing (Month(..), Posix, Zone)
+
+type Locale
+    = US
+    | JP
+
+showLocalDate : Locale -> Int -> Month -> Int -> String
+showLocalDate locale year month day =
+    let
+        yearStr =
+            String.fromInt year
+
+        monthStr =
+            month |> monthToInt |> String.fromInt
+
+        dayStr =
+            String.fromInt day
+    in
+    case locale of
+        US ->
+            monthStr ++ "/" ++ dayStr ++ "/" ++ yearStr
+
+        JP ->
+            yearStr ++ "年" ++ monthStr ++ "月" ++ dayStr ++ "日"
+
+showLocalTime : Locale -> Int -> Int -> String
+showLocalTime locale hour minute =
+    let
+        minuteStr =
+            String.fromInt minute
+    in
+    case locale of
+        US ->
+            let
+                period =
+                    if hour >= 12 then
+                        "PM"
+
+                    else
+                        "AM"
+
+                hour12 =
+                    case modBy 12 hour of
+                        0 ->
+                            12
+
+                        h ->
+                            h
+            in
+            String.fromInt hour12 ++ ":" ++ String.padLeft 2 '0' minuteStr ++ " " ++ period
+
+        JP ->
+            String.fromInt hour ++ "時" ++ minuteStr ++ "分"
+
+showDateTime : Locale -> Zone -> Posix -> String
+showDateTime locale zone posix =
+    let
+        year =
+            Time.toYear zone posix
+
+        month =
+            Time.toMonth zone posix
+
+        day =
+            Time.toDay zone posix
+
+        hour =
+            Time.toHour zone posix
+
+        minute =
+            Time.toMinute zone posix
+
+        monthStr =
+            month |> monthToInt |> String.fromInt
+    in
+    case locale of
+        US ->
+            monthStr ++ "/" ++ String.fromInt day ++ "/" ++ String.fromInt year ++ " " ++ showLocalTime locale hour minute
+
+        JP ->
+            String.fromInt year ++ "年" ++ monthStr ++ "月" ++ String.fromInt day ++ "日" ++ showLocalTime locale hour minute
+
+monthToInt : Month -> Int
+monthToInt month =
+    case month of
+        Jan -> 1
+        Feb -> 2
+        Mar -> 3
+        Apr -> 4
+        May -> 5
+        Jun -> 6
+        Jul -> 7
+        Aug -> 8
+        Sep -> 9
+        Oct -> 10
+        Nov -> 11
+        Dec -> 12
+"""
+                |> Review.Test.run (KurokosClock.usesShowLocalDateAndShowLocalTime comment)
+                |> Review.Test.expectErrors
+                    [ TestHelper.createExpectedErrorUnder
+                        comment
+                        "showDateTime"
+                        |> Review.Test.atExactly { start = { row = 59, column = 1 }, end = { row = 59, column = 13 } }
+                    ]
+
+
+missingShowLocalTime : Test
+missingShowLocalTime =
+    let
+        comment =
+            Comment "elm.kurokos-clock.use_showLocalDate_and_showLocalTime" Essential Dict.empty
+    in
+    test "not using showLocalTime" <|
+        \() ->
+            """
+module KurokosClock exposing (Locale(..), showDateTime, showLocalDate, showLocalTime)
+
+import Time exposing (Month(..), Posix, Zone)
+
+type Locale
+    = US
+    | JP
+
+showLocalDate : Locale -> Int -> Month -> Int -> String
+showLocalDate locale year month day =
+    let
+        yearStr =
+            String.fromInt year
+
+        monthStr =
+            month |> monthToInt |> String.fromInt
+
+        dayStr =
+            String.fromInt day
+    in
+    case locale of
+        US ->
+            monthStr ++ "/" ++ dayStr ++ "/" ++ yearStr
+
+        JP ->
+            yearStr ++ "年" ++ monthStr ++ "月" ++ dayStr ++ "日"
+
+showLocalTime : Locale -> Int -> Int -> String
+showLocalTime locale hour minute =
+    let
+        minuteStr =
+            String.fromInt minute
+    in
+    case locale of
+        US ->
+            let
+                period =
+                    if hour >= 12 then
+                        "PM"
+
+                    else
+                        "AM"
+
+                hour12 =
+                    case modBy 12 hour of
+                        0 ->
+                            12
+
+                        h ->
+                            h
+            in
+            String.fromInt hour12 ++ ":" ++ String.padLeft 2 '0' minuteStr ++ " " ++ period
+
+        JP ->
+            String.fromInt hour ++ "時" ++ minuteStr ++ "分"
+
+showDateTime : Locale -> Zone -> Posix -> String
+showDateTime locale zone posix =
+    let
+        year =
+            Time.toYear zone posix
+
+        month =
+            Time.toMonth zone posix
+
+        day =
+            Time.toDay zone posix
+
+        hour =
+            Time.toHour zone posix
+
+        minute =
+            Time.toMinute zone posix
+
+        minuteStr =
+            String.fromInt minute
+
+        period =
+            if hour >= 12 then
+                "PM"
+
+            else
+                "AM"
+
+        hour12 =
+            case modBy 12 hour of
+                0 ->
+                    12
+
+                h ->
+                    h
+    in
+    case locale of
+        US ->
+            showLocalDate locale year month day ++ " " ++ String.fromInt hour12 ++ ":" ++ String.padLeft 2 '0' minuteStr ++ " " ++ period
+
+        JP ->
+            showLocalDate locale year month day ++ String.fromInt hour ++ "時" ++ minuteStr ++ "分"
+
+monthToInt : Month -> Int
+monthToInt month =
+    case month of
+        Jan -> 1
+        Feb -> 2
+        Mar -> 3
+        Apr -> 4
+        May -> 5
+        Jun -> 6
+        Jul -> 7
+        Aug -> 8
+        Sep -> 9
+        Oct -> 10
+        Nov -> 11
+        Dec -> 12
+"""
+                |> Review.Test.run (KurokosClock.usesShowLocalDateAndShowLocalTime comment)
+                |> Review.Test.expectErrors
+                    [ TestHelper.createExpectedErrorUnder
+                        comment
+                        "showDateTime"
+                        |> Review.Test.atExactly { start = { row = 59, column = 1 }, end = { row = 59, column = 13 } }
+                    ]


### PR DESCRIPTION
Closes #93
[Sister PR here](https://github.com/exercism/website-copy/pull/2383).

Basic rule.
I asked Cursor to write the rule, it did and it ran tests until it was all good, that was pretty cool.
I did edit the result: I removed some overzealous test, and the example code for the failing solutions was almost there, but it didn't pass the actual exercise tests, so I had to tweak them.